### PR TITLE
issue #121 pubannotation未ログイン時のsaveボタン押下でログインウィンドウ表示・ログイン

### DIFF
--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/index.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/index.js
@@ -19,8 +19,18 @@ export default function(
       withCredentials: true
     }
   }
+
+  const retryHandler = () => {
+    $.ajax(opt)
+      .done(successHandler)
+      .fail((ajaxResponse) => serverAuthHandler(ajaxResponse, failHandler))
+      .always(finishHandler)
+  }
+
   $.ajax(opt)
     .done(successHandler)
-    .fail((ajaxResponse) => serverAuthHandler(ajaxResponse, failHandler))
+    .fail((ajaxResponse) =>
+      serverAuthHandler(ajaxResponse, failHandler, retryHandler)
+    )
     .always(finishHandler)
 }

--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/index.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/index.js
@@ -23,7 +23,7 @@ export default function(
   const retryHandler = () => {
     $.ajax(opt)
       .done(successHandler)
-      .fail((ajaxResponse) => serverAuthHandler(ajaxResponse, failHandler))
+      .fail(failHandler)
       .always(finishHandler)
   }
 

--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/LoginInfoDialog/index.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/LoginInfoDialog/index.js
@@ -13,20 +13,12 @@ export default class extends Dialog {
   }
 
   open() {
-    const isHideMessageBox = CookieHandler().get('hide-message-box')
-
-    if (isHideMessageBox === 'true') {
-      // Skip to show login infromation.
-      this.openLoginPageInPopUpWindow()
-    } else {
-      // Show login infromation.
-      super.open()
-    }
+    return this.openLoginPageInPopUpWindow()
   }
 
   // open the login page in a popup window.
   openLoginPageInPopUpWindow() {
-    openPopUp(this._loginUrl)
+    return openPopUp(this._loginUrl)
   }
 
   set hideMessageBox(val) {

--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/LoginInfoDialog/index.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/LoginInfoDialog/index.js
@@ -13,11 +13,6 @@ export default class extends Dialog {
   }
 
   open() {
-    return this.openLoginPageInPopUpWindow()
-  }
-
-  // open the login page in a popup window.
-  openLoginPageInPopUpWindow() {
     return openPopUp(this._loginUrl)
   }
 

--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/LoginInfoDialog/openPopUp.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/LoginInfoDialog/openPopUp.js
@@ -2,5 +2,5 @@ export default function(url) {
   const width = 600
   const height = 500
 
-  window.open(url, '_blank', `width=${width}, height=${height}`)
+  return window.open(url, '_blank', `width=${width}, height=${height}`)
 }

--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/index.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/index.js
@@ -9,7 +9,7 @@ export default function(ajaxResponse, errorHandler, retryHandler) {
 
     // 参考：https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128
     const timer = setInterval(function() {
-      if (win && win.closed) {
+      if (win.closed) {
         clearInterval(timer)
         retryHandler()
       }

--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/index.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/index.js
@@ -9,7 +9,7 @@ export default function(ajaxResponse, errorHandler, retryHandler) {
 
     // 参考：https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128
     const timer = setInterval(function() {
-      if (win.closed) {
+      if (win && win.closed) {
         clearInterval(timer)
         retryHandler()
       }

--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/index.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/index.js
@@ -7,6 +7,7 @@ export default function(ajaxResponse, errorHandler, retryHandler) {
   if (location) {
     const win = new LoginInfoDialog(location).open()
 
+    // 参考：https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128
     const timer = setInterval(function() {
       if (win.closed) {
         clearInterval(timer)

--- a/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/index.js
+++ b/src/lib/editor/DataAccessObject/AjaxSender/requestAjax/serverAuthHandler/index.js
@@ -1,11 +1,18 @@
 import LoginInfoDialog from './LoginInfoDialog'
 import isSeverAuthRequired from './isSeverAuthRequired'
 
-export default function(ajaxResponse, errorHandler) {
+export default function(ajaxResponse, errorHandler, retryHandler) {
   const location = isSeverAuthRequired(ajaxResponse)
 
   if (location) {
-    new LoginInfoDialog(location).open()
+    const win = new LoginInfoDialog(location).open()
+
+    const timer = setInterval(function() {
+      if (win.closed) {
+        clearInterval(timer)
+        retryHandler()
+      }
+    }, 1000)
   } else {
     errorHandler()
   }


### PR DESCRIPTION
#121 

**対応内容**

- pubannotation未ログインの場合はsaveボタン押下で、pubannotationへのログイン用のポップアップウィンドウを開いて、basicまたはgoogleでログインして保存できるように修正

**確認内容**

- pubannotation未ログイン状態であること。

- textaeのアイコン「Upload[U]」押下で、ダイアログ「Save Annotations」が表示される。

- ダイアログ「Save Annotations」のSaveボタン押下で、pubannotationへのログイン用のポップアップウィンドウが表示されること

- basicまたはgoogleでログインすると保存できること

- pubannotation画面の右上にユーザ名が表示・ボタン名（ログイン→ログアウト）が変更されていること


**画面**

_pubannotation未ログイン状態_

<img width="1139" alt="スクリーンショット 2020-09-23 18 41 27" src="https://user-images.githubusercontent.com/39178089/93996153-dc55fd00-fdcc-11ea-9d8c-d1249c22d098.png">

_textaeのアイコン「Upload[U]」押下で、ダイアログ「Save Annotations」表示_

<img width="1035" alt="スクリーンショット 2020-09-23 18 40 56" src="https://user-images.githubusercontent.com/39178089/93996221-f263bd80-fdcc-11ea-8fcd-f860eb2ad648.png">

_Saveボタン押下で、pubannotationへのログイン用のポップアップウィンドウ表示_

<img width="797" alt="スクリーンショット 2020-09-23 18 46 48" src="https://user-images.githubusercontent.com/39178089/93996400-2d65f100-fdcd-11ea-8935-3624f667ee67.png">

_basicまたはgoogleでログインすると保存できる_

<img width="407" alt="スクリーンショット 2020-09-23 18 48 18" src="https://user-images.githubusercontent.com/39178089/93996563-61d9ad00-fdcd-11ea-8233-4f1414f373d2.png">


_ pubannotation画面の右上にユーザ名が表示・ボタン名（ログイン→ログアウト）の変更_

<img width="1111" alt="スクリーンショット 2020-09-23 18 48 42" src="https://user-images.githubusercontent.com/39178089/93996691-82a20280-fdcd-11ea-9973-57c69c090699.png">

