### PR TITLE
Add the ability to upload files by drag and drop to LoadAnnotationsDialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "debounce": "^1.2.1",
         "delegate": "^3.2.0",
         "dohtml": "^0.1.0",
+        "dropzone": "^5.8.1",
         "emitter-fsm": "0.0.2",
         "eskape": "^1.2.0",
         "font-awesome": "^4.7.0",
@@ -1518,6 +1519,11 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
       "dev": true
+    },
+    "node_modules/dropzone": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.8.1.tgz",
+      "integrity": "sha512-1upO44M5CEV5ZNd+HBZ38ziUvlZbMweT8IJsKOYKPALXYk7II5hwvFmy+ggWpyRQYnAKjd3/VJ5ffd9fM+TX3w=="
     },
     "node_modules/duplexer": {
       "version": "0.1.1",
@@ -7781,6 +7787,11 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
       "dev": true
+    },
+    "dropzone": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.8.1.tgz",
+      "integrity": "sha512-1upO44M5CEV5ZNd+HBZ38ziUvlZbMweT8IJsKOYKPALXYk7II5hwvFmy+ggWpyRQYnAKjd3/VJ5ffd9fM+TX3w=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "debounce": "^1.2.1",
     "delegate": "^3.2.0",
     "dohtml": "^0.1.0",
+    "dropzone": "^5.8.1",
     "emitter-fsm": "0.0.2",
     "eskape": "^1.2.0",
     "font-awesome": "^4.7.0",

--- a/src/lib/css/textae-editor-dialog.less
+++ b/src/lib/css/textae-editor-dialog.less
@@ -48,18 +48,38 @@
     .common();
     .save_load();
 
-    &__config-title {
-      .config-title();
-    }
-
-    &__file-name,
-    &__file-name--config {
+    &__file-name {
       .file();
     }
 
-    &__file,
-    &__file--config {
-      .file();
+    &__dropzone {
+      border: 3px dashed;
+      border-radius: 10px;
+      cursor: pointer;
+      height: 100px;
+      margin: 10px auto;
+      width: 500px;
+      .dz-message {
+        font-weight: bold;
+        line-height: 100px;
+        text-align: center;
+      }
+    }
+
+    &__dz-file-preview {
+      display: inline-block;
+      width: 348px;
+      .dz-filename {
+        align-items: center;
+        display: flex;
+        span {
+          display: inline-block;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          width: 348px;
+        }
+      }
     }
   }
 

--- a/src/lib/editor/start/PersistenceInterface/index.js
+++ b/src/lib/editor/start/PersistenceInterface/index.js
@@ -35,9 +35,9 @@ export default class PersistenceInterface {
       'Load Annotations',
       this._dataAccessObject.annotationUrl,
       (url) => this._dataAccessObject.loadAnnotation(url),
-      ({ files }) => {
-        readAnnotationFile(files, this._editor)
-        this._filenameOfLastRead.annotation = files[0].name
+      (file) => {
+        readAnnotationFile(file, this._editor)
+        this._filenameOfLastRead.annotation = file.name
       },
       this._history.hasAnythingToSaveAnnotation
     ).open()

--- a/src/lib/editor/start/PersistenceInterface/readAnnotationFile.js
+++ b/src/lib/editor/start/PersistenceInterface/readAnnotationFile.js
@@ -3,8 +3,7 @@ import isJSON from './isJSON'
 import isTxtFile from './isTxtFile'
 import DataSource from '../../DataSource'
 
-export default async function (files, editor) {
-  const file = files[0]
+export default async function (file, editor) {
   const event = await readFile(file)
   const fileContent = event.target.result
 


### PR DESCRIPTION
## Purpose
Added the ability to upload files by drag and drop to LoadAnnotationDialog.
You can drag and drop not only the drop zone inside the dialog, but also the background outside the dialog.
You can also select files as before by clicking the drop zone.

[![Image from Gyazo](https://i.gyazo.com/ec9d6542adcf3333f934c8cfe51632d3.gif)](https://gyazo.com/ec9d6542adcf3333f934c8cfe51632d3)