### PR TITLE
Modify dropzone in load dialog

### DIFF
--- a/src/lib/component/LoadDialog.js
+++ b/src/lib/component/LoadDialog.js
@@ -26,19 +26,19 @@ function template(context) {
       Local
     </label>
     <div class="textae-editor__load-dialog__dz-file-preview">
-      <div class="dz-filename"><span data-dz-name>No file uploaded</span></div>
+      <div class="dz-filename"><span data-dz-name>No file selected</span></div>
     </div>
     <input 
       type="button" 
       class="local"
       disabled="disabled"
       value="Open">
+    <form class="dropzone textae-editor__load-dialog__dropzone">
+      <div class="dz-message">
+        Drop a file here or click to select
+      </div>
+    </form>
   </div>
-  <form class="dropzone textae-editor__load-dialog__dropzone">
-    <div class="dz-message">
-      Drop a file here or click to upload.
-    </div>
-  </form>
 </div>`
 }
 

--- a/src/lib/css/textae-editor-dialog.less
+++ b/src/lib/css/textae-editor-dialog.less
@@ -56,12 +56,17 @@
       border: 3px dashed;
       border-radius: 10px;
       cursor: pointer;
-      height: 100px;
-      margin: 10px auto;
-      width: 500px;
+      height: 40px;
+      margin: 10px 0 10px 64px;
+      transition-duration: 0.3s;
+      width: 65%;
+      &:hover {
+        box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.4);
+        transform: scale(1.05);
+      }
       .dz-message {
         font-weight: bold;
-        line-height: 100px;
+        line-height: 40px;
         text-align: center;
       }
     }


### PR DESCRIPTION
## Purpose
Modified the wording of the drop zone and preview, adjusted the size of the drop zone and added a reaction when the mouse is over.

[![Image from Gyazo](https://i.gyazo.com/daf83b58e28a86b40430dbb23d62b6a9.gif)](https://gyazo.com/daf83b58e28a86b40430dbb23d62b6a9)