### PR TITLE
Added HTTP header on save request

### DIFF
--- a/src/lib/Editor/RemoteResource/ConfigurationSaver.js
+++ b/src/lib/Editor/RemoteResource/ConfigurationSaver.js
@@ -16,7 +16,8 @@ export default class ConfigurationSaver {
       const opt = {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'App-Name': 'TextAE'
         },
         body: JSON.stringify(editedData),
         credentials: 'include'


### PR DESCRIPTION
## 概要
PubAnnotationでTextAEを識別するために、保存リクエストにHTTPヘッダーを追加しました。

## 実装内容
- ConfigurationSaverクラスのsaveToメソッドに`App-Name`ヘッダーを追加

## 動作確認
PubAnnotation側でヘッダーが取得できていることを確認しました。
```
15:26:51 web.1    |    119|   # POST /annotations
15:26:51 web.1    |    120|   # POST /annotations.json
15:26:51 web.1    |    121|   def create
15:26:51 web.1    | => 122|     binding.break
15:26:51 web.1    |    123|     unless user_signed_in?
15:26:51 web.1    |    124|       # for TextAE
15:26:51 web.1    |    125|       if request.headers['App-Name'] == 'TextAE'
15:26:51 web.1    |    126|         response.headers['WWW-Authenticate'] = 'ServerPage'
15:26:51 web.1    | =>#0 AnnotationsController#create at ~/develop/pubannotation/app/controllers/annotations_controller.rb:122
15:26:51 web.1    |   #1 ActionController::BasicImplicitRender#send_action(method="create", args=[]) at ~/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/actionpack-7.2.1/lib/action_controller/metal/basic_implicit_render.rb:8
15:26:51 web.1    |   # and 75 frames (use `bt' command for all frames)
(ruby) request.headers['App-Name']
"TextAE"
```