### PR TITLE
Fix configuration format of attribute values

### DIFF
--- a/src/lib/AttributeDefinition.js
+++ b/src/lib/AttributeDefinition.js
@@ -23,10 +23,10 @@ export default class AttributeDefinition {
       return undefined
     }
 
-    const values = []
+    const result = []
     for (const value of this._values) {
-      values.push({ ...value })
+      result.push({ ...value })
     }
-    return values
+    return result
   }
 }

--- a/src/lib/AttributeDefinition.js
+++ b/src/lib/AttributeDefinition.js
@@ -19,7 +19,7 @@ export default class AttributeDefinition {
   get _valuesClone() {
     console.assert(this._values, 'this._values is necessary to clone!')
 
-    if (this._values.length === 0) {
+    if (Array.isArray(this._values) && this._values.length === 0) {
       return undefined
     }
 

--- a/src/lib/AttributeDefinition.js
+++ b/src/lib/AttributeDefinition.js
@@ -19,6 +19,10 @@ export default class AttributeDefinition {
   get _valuesClone() {
     console.assert(this._values, 'this._values is necessary to clone!')
 
+    if (this._values.length === 0) {
+      return undefined
+    }
+
     const values = []
     for (const value of this._values) {
       values.push({ ...value })


### PR DESCRIPTION
## 概要
string attribute のvaluesに空の配列が生える問題を修正しました。

## 修正内容
- 保存するデータと元のデータの形式を比較し、`values`値が「元のデータにない」かつ「新しいデータは空配列」の場合に新しいデータから'values'プロパティを削除する処理を追加

## 動作確認
使用データ
```
"attribute types": [
  {
    "pred": "free_text_predicate",
    "value type": "string",
    "autocompletion_ws": "/dev/autocomplete?order=desc",
    "default": "Down the Rabbit Hole",
    "media height": 90
  },
  {
    "pred": "score2",
    "value type": "numeric"
  }
]
```

#### 修正前
|<img width="530" alt="image" src="https://github.com/user-attachments/assets/da2a332b-30e1-45d0-8496-623295c39e45">|
|:-|

#### 修正後
|<img width="527" alt="image" src="https://github.com/user-attachments/assets/8e8433d7-369b-4059-b3b1-d31b6c4d62aa">|
|:-|

### Build確認
lint含めて問題なくbuildできることを確認しました。
<details>
<summary>npm run dist結果</summary>

```
➜  textae git:(fix/configuration_format_of_attribute_values) npm run dist

> textae@13.4.0 dist
> npm-run-all dist:clean dist:build dist:copy dist:replace:version


> textae@13.4.0 dist:clean
> rimraf dist/* tmp/$npm_package_name-*.js tmp/$npm_package_name-*.min.js tmp/css/textae-*.css


> textae@13.4.0 dist:build
> npm-run-all -p dist:build:**


> textae@13.4.0 dist:build:js
> npm-run-all dist:lint dist:bundle


> textae@13.4.0 dist:build:css
> npm-run-all dist:less dist:cleancss


> textae@13.4.0 dist:lint
> npx prettier --check 'src/lib/**/*.js' 'src/lib/css/*.less' && eslint src/lib


> textae@13.4.0 dist:less
> lessc 'src/lib/css/textae.less' tmp/css/$npm_package_name-$npm_package_version.css


> textae@13.4.0 dist:cleancss
> cleancss -o tmp/css/$npm_package_name-$npm_package_version.min.css tmp/css/$npm_package_name-$npm_package_version.css

Checking formatting...
All matched files use Prettier code style!

> textae@13.4.0 dist:bundle
> webpack --config webpack.prod.js

asset textae-13.4.0.js 3.1 MiB [emitted] (name: textae-13.4.0)
asset textae-13.4.0.min.js 1.21 MiB [emitted] [minimized] (name: textae-13.4.0.min)
orphan modules 1.88 MiB [orphan] 530 modules
runtime modules 1.73 KiB 8 modules
cacheable modules 3.08 MiB
  modules by path ./node_modules/ajv/dist/ 204 KiB 63 modules
  modules by path ./node_modules/jquery-ui/ui/ 201 KiB 22 modules
  modules by path ./node_modules/fast-uri/ 20 KiB 4 modules
  modules by path ./node_modules/ajv-formats/dist/*.js 16.3 KiB 3 modules
  modules by path ./node_modules/delegate/src/*.js 2.91 KiB 2 modules
  modules by path ./node_modules/dohtml/ 1.59 KiB 2 modules
  modules by path ./node_modules/sticky-js/ 16.4 KiB
    ./node_modules/sticky-js/index.js 77 bytes [built] [code generated]
    ./node_modules/sticky-js/dist/sticky.compile.js 16.3 KiB [built] [code generated]
  + 12 modules
webpack 5.95.0 compiled successfully in 4139 ms

> textae@13.4.0 dist:copy
> npm-run-all -p dist:copy:**


> textae@13.4.0 dist:copy:demo
> cpx 'src/demo/**' dist/demo


> textae@13.4.0 dist:copy:js
> cpx tmp/$npm_package_name-$npm_package_version'*'.js dist/lib


> textae@13.4.0 dist:copy:fonts
> cpx 'src/lib/fonts/**' dist/lib/fonts


> textae@13.4.0 dist:copy:css
> cpx tmp/css/$npm_package_name-$npm_package_version'*'.css dist/lib/css


> textae@13.4.0 dist:copy:app
> cpx src/app/editor.html dist


> textae@13.4.0 dist:copy:images
> cpx 'src/lib/css/images/**.png' dist/lib/css/images


> textae@13.4.0 dist:replace:version
> replace-in-file /{{version}}/g $npm_package_version dist/editor.html,dist/demo/**/*.html --isRegex

Replacing '/{{version}}/g' with '13.4.0'
7 file(s) were changed
```

</details>