### PR TITLE
Enable to select text-edit mode on StartUpOptions

### DIFF
--- a/src/lib/Editor/StartUpOptions/index.js
+++ b/src/lib/Editor/StartUpOptions/index.js
@@ -83,6 +83,7 @@ export default class StartUpOptions {
       case 'term-edit':
       case 'block-edit':
       case 'relation-edit':
+      case 'text-edit':
         return true
 
       default:
@@ -104,6 +105,10 @@ export default class StartUpOptions {
 
   get isEditRelationMode() {
     return this.#readAttribute('mode') === 'relation-edit'
+  }
+
+  get isTextEditMode() {
+    return this.#readAttribute('mode') === 'text-edit'
   }
 
   get statusBar() {

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
@@ -161,7 +161,9 @@ export default class EditModeSwitch {
     }
 
     if (this.#startUpOptions.isTextEditMode) {
-      this.#editModeState.toTextEditMode()
+      this.#editModeState.toTextEditMode(
+        this.#annotationModel.relationInstanceContainer.some
+      )
       return
     }
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
@@ -160,6 +160,11 @@ export default class EditModeSwitch {
       return
     }
 
+    if (this.#startUpOptions.isTextEditMode) {
+      this.#editModeState.toTextEditMode()
+      return
+    }
+
     this.#editModeState.toViewMode(
       this.#annotationModel.relationInstanceContainer.some
     )


### PR DESCRIPTION
## 概要
初期編集モードの選択肢にtext-editモードを追加しました。

## 行ったこと
- 初期編集モードの選択肢にtext-editモードを追加

## 動作確認
HTMLのmode属性に`text-edit`を指定
```
<div
    class="textae-editor"
    title="editor0"
    mode="text-edit"
    inspect="abc"
    status_bar="on"
    source="https://pubannotation.org/projects/DisGeNET/docs/sourcedb/PubMed/sourceid/10021369/annotations.json"
    config_lock="true"
    style="height: 400px; overflow-y: scroll;"
    ignore_annotation_parameter="true"
></div>
```

ロードすると以下のようにtext-editモードが選択された状態になります。
|<img width="888" alt="image" src="https://github.com/user-attachments/assets/531ad2f1-0e8c-4edc-82b1-76fcf8fdf6f4">|
|:-|

そのままテキストを選択して機能自体も動作することを確認しました。
|<img width="1184" alt="image" src="https://github.com/user-attachments/assets/27e93c91-13fe-4e0b-8905-af61abc1a705">|
|:-|