### PR TITLE
Fix enterkey operation in Autcomplete

### DIFF
--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -35,7 +35,7 @@ export default class Autocomplete {
       this.#handleKeydown(event)
     )
     this.#inputElement.addEventListener('keyup', (event) =>
-      this.#handleEnterKey(event)
+      this.#handleKeyup(event)
     )
 
     // Hide popover when input is out of focus.
@@ -102,7 +102,7 @@ export default class Autocomplete {
     }
   }
 
-  #handleEnterKey(event) {
+  #handleKeyup(event) {
     if (event.key === 'Enter' && this.#model.itemsCount > 0) {
       event.stopPropagation()
 

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -34,6 +34,9 @@ export default class Autocomplete {
     this.#inputElement.addEventListener('keydown', (event) =>
       this.#handleKeydown(event)
     )
+    this.#inputElement.addEventListener('keyup', (event) =>
+      this.#handleEnterKey(event)
+    )
 
     // Hide popover when input is out of focus.
     this.#inputElement.addEventListener('blur', () =>
@@ -96,19 +99,23 @@ export default class Autocomplete {
         event.preventDefault()
         this.#model.moveHighlightIndexPrevious()
         break
+    }
+  }
 
-      case 'Enter': {
-        event.preventDefault()
-        const currentItem = document.querySelector(
-          '.textae-editor__dialog__autocomplete__item--highlighted'
-        )
+  #handleEnterKey(event) {
+    if (event.key === 'Enter' && this.#model.itemsCount > 0) {
+      event.stopPropagation()
 
-        if (currentItem) {
-          this.#onSelect(currentItem.dataset.id, currentItem.dataset.label)
-          this.#resultsElement.hidePopover()
-        }
-        break
+      const currentItem = document.querySelector(
+        '.textae-editor__dialog__autocomplete__item--highlighted'
+      )
+
+      if (currentItem) {
+        this.#onSelect(currentItem.dataset.id, currentItem.dataset.label)
       }
+
+      this.#model.items = []
+      this.#resultsElement.hidePopover()
     }
   }
 

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -115,7 +115,6 @@ export default class Autocomplete {
       }
 
       this.#model.items = []
-      this.#resultsElement.hidePopover()
     }
   }
 

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -104,6 +104,7 @@ export default class Autocomplete {
 
   #handleKeyup(event) {
     if (event.key === 'Enter' && this.#model.itemsCount > 0) {
+      // Prevent dialog closing event to close only popover by Enter.
       event.stopPropagation()
 
       const currentItem = document.querySelector(


### PR DESCRIPTION
## 概要
オートコンプリート候補に対してエンターキーを押下すると、値の代入後にダイアログまで閉じてしまう問題がありました。
この問題を修正しました。

## 実装内容
- エンターキーによる値の代入を`keyup`イベントに変更
  - ダイアログを閉じるイベントと同じイベントタイプに合わせ、`stopPropagation`によるバブリング停止を追加
- オートコンプリート機能におけるエンターキーのイベントは、popoverが表示されている状態のみ動作するように条件を追加

## 動作確認
### エンターによって値が代入されるがダイアログが閉じない
候補が表示されていない状態であれば、再度エンターを押すことで保存とダイアログを閉じるイベントは発生します。

https://github.com/user-attachments/assets/f7d25830-d507-40df-934c-cafe195df738

### 候補を選択しない状態でエンターを押すと元の値で決定される
https://github.com/user-attachments/assets/cafaa581-2dcf-4975-adfb-ce8407286dc4

