### PR TITLE
Add item clear method to Autocomplete model

### DIFF
--- a/src/lib/component/autocomplete/autocompleteModel.js
+++ b/src/lib/component/autocomplete/autocompleteModel.js
@@ -22,7 +22,7 @@ export default class AutocompleteModel {
     if (this.#term.length >= 3) {
       this.#onTermChange(this.#term)
     } else {
-      this.items = [] // Clear items.
+      this.clearItems()
     }
   }
 
@@ -43,6 +43,10 @@ export default class AutocompleteModel {
   set highlightedIndex(value) {
     this.#highlightedIndex = value
     this.#onHighlightIndexChange(this.#highlightedIndex)
+  }
+
+  clearItems() {
+    this.items = []
   }
 
   moveHighlightIndexPrevious() {

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -115,7 +115,7 @@ export default class Autocomplete {
         this.#onSelect(currentItem.dataset.id, currentItem.dataset.label)
       }
 
-      this.#model.items = []
+      this.#model.clearItems()
     }
   }
 


### PR DESCRIPTION
## 概要
以下の別PRでのコメント対応として、itemsデータ構造を隠蔽するためにAutocompleteモデルにメソッドを追加しました。
https://github.com/pubannotation/textae/pull/143#discussion_r1819984249

## 行ったこと
- Autocompleteモデルにitemsを空にするメソッドを追加
- 上記メソッドを利用するようにコードを修正

## 動作確認
動作OKです。

https://github.com/user-attachments/assets/3b31c5a0-8da9-4c6f-bd48-a87f37c693c9