### PR TITLE
Fix drag and drop not working

### DIFF
--- a/src/lib/component/TypeValuesPallet/createContentHtml/headerTemplate/attributeTabTemplate.js
+++ b/src/lib/component/TypeValuesPallet/createContentHtml/headerTemplate/attributeTabTemplate.js
@@ -21,7 +21,7 @@ export default function ({ pred }, index, array, selectedPred) {
       }"
       data-attribute="${pred}"
       data-index="${index}"
-      ${pred === selectedPred ? 'draggable="true"' : ''}>
+      ${pred === selectedPred ? 'draggable=true' : ''}>
       ${index < 9 ? `${index + 1}:` : ''}${pred}
     </p>
   `


### PR DESCRIPTION
## 概要
パレットのアトリビュートタブの順序をドラッグ＆ドロップで入れ替えられる機能が動かない問題を修正しました。

## 行ったこと
- 生成するHTMLのdraggable属性が正しくtrueと判断されるように修正

## 動作確認
https://github.com/user-attachments/assets/36e25997-7814-4b67-9f43-be8caa6b3c1c