### PR TITLE
Allow enterkey saving with label input

### DIFF
--- a/src/lib/component/TypeDefinitionDialog/template.js
+++ b/src/lib/component/TypeDefinitionDialog/template.js
@@ -12,7 +12,9 @@ export default function template(context) {
   </div>
   <div class="textae-editor__type-definition-dialog__row ui-front">
     <label>Label<span></span></label>
-    <input value="${label}">
+    <input
+      class ="textae-editor__promise-dialog__observable-element"
+      value="${label}">
   </div>
   <div class="textae-editor__type-definition-dialog__color-picker">
     <label><input


### PR DESCRIPTION
## 概要
TypeDefinitionDialogのEdit typeでは、label inputも入力が可能です。
しかし、label inputではId inputのようにエンターキーによる保存&ダイアログを閉じる操作が行えませんでした。
そこで、label inputでもエンターキーによる保存&ダイアログを閉じる操作を可能にするように変更しました。
<img width="596" alt="image" src="https://github.com/user-attachments/assets/34ba378e-9689-42f6-bd31-576d789fed41">

## 行ったこと
- label inputのHTMLに`textae-editor__promise-dialog__observable-element`クラス属性を追加

これにより、保存&ダイアログを閉じる操作を行う対象にすることができます。
https://github.com/pubannotation/textae/blob/efad0f6bdd866887a5897cbe3545dd4188dcec7e/src/lib/component/PromiseDialog.js#L25

`textae-editor__promise-dialog__observable-element`クラスに対して処理を行っているのは上記のPromiseDialogクラスのみで、クラス追加による副作用がないことも確認しました。

## 動作確認
https://github.com/user-attachments/assets/d9bf0362-469b-43c2-9ea4-be3d99c90fd2