### PR TITLE
Add tab key operation to autocomplete

### DIFF
--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -62,6 +62,15 @@ export default class Autocomplete {
         event.preventDefault()
         this.#model.moveHighlightIndexPrevious()
         break
+
+      case 'Tab':
+        event.preventDefault()
+        if (event.shiftKey) {
+          this.#model.moveHighlightIndexPrevious()
+        } else {
+          this.#model.moveHighlightIndexNext()
+        }
+        break
     }
   }
 


### PR DESCRIPTION
## 概要
オートコンプリートの候補をTabキーで移動する機能を追加しました。

## 行ったこと
- Tabキーでのハイライト移動（進む）を追加
- Tab + Shiftでのハイライト移動（戻る）を追加

## 動作確認
以下の点を確認しました。
- Tabキーで候補のハイライトを移動（進む）できる
- Tab + Shiftで候補のハイライトを移動（戻る）できる
- 候補が表示中はデフォルト動作が無効化されている
- 候補が表示されていない状態ではデフォルト動作が機能する

https://github.com/user-attachments/assets/c21ab64f-27cb-4dc7-ba85-97d0b741ac1b