### PR TITLE
Add escape key operation on autocomplete

### DIFF
--- a/src/lib/component/autocomplete/autocompleteModel.js
+++ b/src/lib/component/autocomplete/autocompleteModel.js
@@ -30,6 +30,14 @@ export default class AutocompleteModel {
     return this.#items.length
   }
 
+  get hasItems() {
+    return this.#items.length > 0
+  }
+
+  get hasNoItems() {
+    return this.#items.length === 0
+  }
+
   set items(value) {
     this.#items = value
     this.#highlightedIndex = -1 // Clear highlight.

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -71,6 +71,14 @@ export default class Autocomplete {
           this.#model.moveHighlightIndexNext()
         }
         break
+
+      case 'Escape':
+        if (this.#model.itemsCount > 0) {
+          event.preventDefault()
+          this.#model.clearItems()
+          this.#itemsContainer.element.hidePopover()
+        }
+        break
     }
   }
 

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -50,7 +50,7 @@ export default class Autocomplete {
   }
 
   #handleKeydown(event) {
-    if (this.#model.itemsCount === 0) return
+    if (this.#model.hasNoItems) return
 
     switch (event.key) {
       case 'ArrowDown':
@@ -73,7 +73,7 @@ export default class Autocomplete {
         break
 
       case 'Escape':
-        if (this.#model.itemsCount > 0) {
+        if (this.#model.hasItems) {
           event.preventDefault()
           this.#model.clearItems()
           this.#itemsContainer.element.hidePopover()
@@ -83,7 +83,7 @@ export default class Autocomplete {
   }
 
   #handleKeyup(event) {
-    if (event.key === 'Enter' && this.#model.itemsCount > 0) {
+    if (event.key === 'Enter' && this.#model.hasItems) {
       // Prevent dialog closing event to close only popover by Enter.
       event.stopPropagation()
 

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -75,7 +75,6 @@ export default class Autocomplete {
       case 'Escape':
         event.preventDefault()
         this.#model.clearItems()
-        this.#itemsContainer.element.hidePopover()
         break
     }
   }

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -73,11 +73,9 @@ export default class Autocomplete {
         break
 
       case 'Escape':
-        if (this.#model.hasItems) {
-          event.preventDefault()
-          this.#model.clearItems()
-          this.#itemsContainer.element.hidePopover()
-        }
+        event.preventDefault()
+        this.#model.clearItems()
+        this.#itemsContainer.element.hidePopover()
         break
     }
   }


### PR DESCRIPTION
## 概要
ESCAPEキーによってオートコンプリートのポップオーバーを閉じる機能を追加しました。

## 行ったこと
- キー操作のメソッドにESCAPEキーの設定を追加
- ミニリファクタリング(モデルのitems状態を取得するゲッターを追加)

## 動作確認
https://github.com/user-attachments/assets/2fa89957-1100-4a69-b4dd-fea3c421641e