### PR TITLE
Fix autocomplete does not work after add predicate

### DIFF
--- a/src/lib/component/EditPropertiesDialog/index.js
+++ b/src/lib/component/EditPropertiesDialog/index.js
@@ -156,10 +156,15 @@ export default class EditPropertiesDialog extends PromiseDialog {
           attributeContainer,
           definitionContainer
         )
+        this.#setupAutocomplete(autocompletionWs, definitionContainer)
       }
     )
 
     // Setup autocomplete
+    this.#setupAutocomplete(autocompletionWs, definitionContainer)
+  }
+
+  #setupAutocomplete(autocompletionWs, definitionContainer) {
     const typeNameElement = super.el.querySelector(
       '.textae-editor__edit-type-values-dialog__type-name'
     )

--- a/src/lib/component/EditPropertiesDialog/index.js
+++ b/src/lib/component/EditPropertiesDialog/index.js
@@ -68,7 +68,8 @@ export default class EditPropertiesDialog extends PromiseDialog {
                   typeName,
                   attributes,
                   attributeContainer,
-                  definitionContainer
+                  definitionContainer,
+                  autocompletionWs
                 )
               })
             break
@@ -81,7 +82,8 @@ export default class EditPropertiesDialog extends PromiseDialog {
                   typeName,
                   attributes,
                   attributeContainer,
-                  definitionContainer
+                  definitionContainer,
+                  autocompletionWs
                 )
               })
             break
@@ -99,7 +101,8 @@ export default class EditPropertiesDialog extends PromiseDialog {
                   typeName,
                   attributes,
                   attributeContainer,
-                  definitionContainer
+                  definitionContainer,
+                  autocompletionWs
                 )
               })
             break
@@ -122,7 +125,8 @@ export default class EditPropertiesDialog extends PromiseDialog {
           typeName,
           attributes.filter((_, i) => i !== indexOfAttribute),
           attributeContainer,
-          definitionContainer
+          definitionContainer,
+          autocompletionWs
         )
       }
     )
@@ -154,9 +158,9 @@ export default class EditPropertiesDialog extends PromiseDialog {
             .concat({ pred, obj: defaultValue, id: '' })
             .sort((a, b) => attributeContainer.attributeCompareFunction(a, b)),
           attributeContainer,
-          definitionContainer
+          definitionContainer,
+          autocompletionWs
         )
-        this.#setupAutocomplete(autocompletionWs, definitionContainer)
       }
     )
 
@@ -187,7 +191,13 @@ export default class EditPropertiesDialog extends PromiseDialog {
     )
   }
 
-  #updateDisplay(typeName, attributes, attributeContainer, entityContainer) {
+  #updateDisplay(
+    typeName,
+    attributes,
+    attributeContainer,
+    entityContainer,
+    autocompletionWs
+  ) {
     const contentHtml = createContentHTML(
       typeName,
       attributes,
@@ -195,5 +205,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
       attributeContainer
     )
     super.el.closest('.ui-dialog-content').innerHTML = contentHtml
+
+    this.#setupAutocomplete(autocompletionWs, entityContainer)
   }
 }


### PR DESCRIPTION
## 概要
EditPropertiesDialogにてpredicateを追加後にオートコンプリート機能が動作しなくなる問題を修正しました。

## 行ったこと
- predicates追加後のHTML再描画後にもAutocompleteを初期化するように変更

## 動作確認
https://github.com/user-attachments/assets/a7b563d9-6a4a-486d-bc60-0d1a80c9bf4d