### PR TITLE
Fix label disappear after dialog update

### DIFF
--- a/src/lib/component/EditPropertiesDialog/createContentHTML/index.js
+++ b/src/lib/component/EditPropertiesDialog/createContentHTML/index.js
@@ -5,6 +5,7 @@ import toAddAttributeButton from './toAddAttributeButton'
 
 export default function (
   typeName,
+  typeLabel,
   attributes,
   entityContainer,
   attributeContainer,
@@ -21,7 +22,7 @@ export default function (
           </tr>
         </thead>
         <tbody>
-          ${toEntityHTML(typeName, entityContainer)}
+          ${toEntityHTML(typeName, typeLabel, entityContainer)}
           ${attributes.map((a, index, list) =>
             toAttributeHTML(a, index, list, attributeContainer)
           )}

--- a/src/lib/component/EditPropertiesDialog/createContentHTML/index.js
+++ b/src/lib/component/EditPropertiesDialog/createContentHTML/index.js
@@ -7,7 +7,6 @@ export default function (
   typeName,
   typeLabel,
   attributes,
-  entityContainer,
   attributeContainer,
   palletName
 ) {
@@ -22,7 +21,7 @@ export default function (
           </tr>
         </thead>
         <tbody>
-          ${toEntityHTML(typeName, typeLabel, entityContainer)}
+          ${toEntityHTML(typeName, typeLabel)}
           ${attributes.map((a, index, list) =>
             toAttributeHTML(a, index, list, attributeContainer)
           )}

--- a/src/lib/component/EditPropertiesDialog/createContentHTML/toEntityHTML.js
+++ b/src/lib/component/EditPropertiesDialog/createContentHTML/toEntityHTML.js
@@ -1,8 +1,6 @@
 import anemone from '../../anemone'
 
-export default function (value, typeLabel, entityContainer) {
-  const label = entityContainer.getLabel(value) || typeLabel
-
+export default function (value, label) {
   return () => anemone`
     <tr>
       <td rowspan="2"></td>

--- a/src/lib/component/EditPropertiesDialog/createContentHTML/toEntityHTML.js
+++ b/src/lib/component/EditPropertiesDialog/createContentHTML/toEntityHTML.js
@@ -1,7 +1,7 @@
 import anemone from '../../anemone'
 
-export default function (value, entityContainer) {
-  const label = entityContainer.getLabel(value) || ''
+export default function (value, typeLabel, entityContainer) {
+  const label = entityContainer.getLabel(value) || typeLabel
 
   return () => anemone`
     <tr>

--- a/src/lib/component/EditPropertiesDialog/index.js
+++ b/src/lib/component/EditPropertiesDialog/index.js
@@ -24,6 +24,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
     const { typeName, attributes } = mergedTypeValuesOf(selectedItems)
     const contentHtml = createContentHTML(
       typeName,
+      '',
       attributes,
       definitionContainer,
       attributeContainer,
@@ -52,7 +53,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
         const zIndex = parseInt(
           super.el.closest('.textae-editor__dialog').style['z-index']
         )
-        const { typeName, attributes } = getValues(super.el)
+        const { typeName, label, attributes } = getValues(super.el)
 
         switch (attrDef.valueType) {
           case 'numeric':
@@ -66,6 +67,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
                 attributes[e.target.dataset.index].obj = newObj
                 this.#updateDisplay(
                   typeName,
+                  label,
                   attributes,
                   attributeContainer,
                   definitionContainer,
@@ -80,6 +82,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
                 attributes[e.target.dataset.index].obj = newObj
                 this.#updateDisplay(
                   typeName,
+                  label,
                   attributes,
                   attributeContainer,
                   definitionContainer,
@@ -99,6 +102,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
                 attributes[e.target.dataset.index].label = newLabel
                 this.#updateDisplay(
                   typeName,
+                  label,
                   attributes,
                   attributeContainer,
                   definitionContainer,
@@ -120,9 +124,10 @@ export default class EditPropertiesDialog extends PromiseDialog {
       (e) => {
         const { index } = e.target.dataset
         const indexOfAttribute = parseInt(index)
-        const { typeName, attributes } = getValues(super.el)
+        const { typeName, label, attributes } = getValues(super.el)
         this.#updateDisplay(
           typeName,
+          label,
           attributes.filter((_, i) => i !== indexOfAttribute),
           attributeContainer,
           definitionContainer,
@@ -151,9 +156,10 @@ export default class EditPropertiesDialog extends PromiseDialog {
         const { pred } = e.target.dataset
         const defaultValue = attributeContainer.get(pred).default
 
-        const { typeName, attributes } = getValues(super.el)
+        const { typeName, label, attributes } = getValues(super.el)
         this.#updateDisplay(
           typeName,
+          label,
           attributes
             .concat({ pred, obj: defaultValue, id: '' })
             .sort((a, b) => attributeContainer.attributeCompareFunction(a, b)),
@@ -193,6 +199,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
 
   #updateDisplay(
     typeName,
+    typeLabel,
     attributes,
     attributeContainer,
     entityContainer,
@@ -200,6 +207,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
   ) {
     const contentHtml = createContentHTML(
       typeName,
+      typeLabel,
       attributes,
       entityContainer,
       attributeContainer

--- a/src/lib/component/EditPropertiesDialog/index.js
+++ b/src/lib/component/EditPropertiesDialog/index.js
@@ -22,11 +22,11 @@ export default class EditPropertiesDialog extends PromiseDialog {
     mousePoint
   ) {
     const { typeName, attributes } = mergedTypeValuesOf(selectedItems)
+    const typeLabel = definitionContainer.getLabel(typeName)
     const contentHtml = createContentHTML(
       typeName,
-      '',
+      typeLabel,
       attributes,
-      definitionContainer,
       attributeContainer,
       palletName
     )
@@ -209,7 +209,6 @@ export default class EditPropertiesDialog extends PromiseDialog {
       typeName,
       typeLabel,
       attributes,
-      entityContainer,
       attributeContainer
     )
     super.el.closest('.ui-dialog-content').innerHTML = contentHtml


### PR DESCRIPTION
Closes: #151

## 概要
editPropertiesDialogでHTMLを更新する操作（アトリビュートの追加、削除等）を行うと、代入されていたlabelの値が消える問題を修正しました。

該当issue: https://github.com/pubannotation/textae/issues/151

## 行なったこと
- editPropertiesDialog#updateDisplayにlabelの値を渡してHTML更新時にlabelの値を利用する形に変更

## 動作確認
labelの値が保持されていることが確認できます。

https://github.com/user-attachments/assets/6bbd3a94-dfb5-4e05-be99-59e8e81d19c5