### PR TITLE
Fix and refactor autocomplete function

### DIFF
--- a/src/lib/component/autocomplete/ItemContainer.js
+++ b/src/lib/component/autocomplete/ItemContainer.js
@@ -10,6 +10,8 @@ export default class ItemContainer {
     this.#container.setAttribute('popover', 'auto')
     this.#container.classList.add('textae-editor__dialog__autocomplete')
     inputElement.parentElement.appendChild(this.#container)
+
+    window.addEventListener('resize', this.#moveUnderInputElement.bind(this))
   }
 
   get element() {

--- a/src/lib/component/autocomplete/autocompleteModel.js
+++ b/src/lib/component/autocomplete/autocompleteModel.js
@@ -1,17 +1,17 @@
 export default class AutocompleteModel {
-  static #TERM_MIN_LENGTH = 3
-
   #onTermChange
   #onItemsChange
   #onHighlightIndexChange
+  #termMinLength
   #term = ''
   #items = []
   #highlightedIndex = -1
 
-  constructor(onTermChange, onItemsChange, onHighlightIndexChange) {
+  constructor(onTermChange, onItemsChange, onHighlightIndexChange, minLength) {
     this.#onTermChange = onTermChange
     this.#onItemsChange = onItemsChange
     this.#onHighlightIndexChange = onHighlightIndexChange
+    this.#termMinLength = minLength
   }
 
   get term() {
@@ -21,7 +21,7 @@ export default class AutocompleteModel {
   set term(value) {
     this.#term = value
 
-    if (this.#term.length >= AutocompleteModel.#TERM_MIN_LENGTH) {
+    if (this.#term.length >= this.#termMinLength) {
       this.#onTermChange(this.#term)
     } else {
       this.clearItems()

--- a/src/lib/component/autocomplete/index.js
+++ b/src/lib/component/autocomplete/index.js
@@ -8,14 +8,15 @@ export default class Autocomplete {
   #model
   #itemsContainer
 
-  constructor(inputElement, onSearch, onSelect) {
+  constructor(inputElement, onSearch, onSelect, minLength = 3) {
     this.#onSelect = onSelect
     this.#itemsContainer = new ItemContainer(inputElement)
 
     this.#model = new AutocompleteModel(
       (term) => onSearch(term, (results) => (this.#model.items = results)),
       (items) => (this.#itemsContainer.items = items),
-      (index) => this.#itemsContainer.highlight(index)
+      (index) => this.#itemsContainer.highlight(index),
+      minLength
     )
 
     this.#setEventHandlersToInput(inputElement)


### PR DESCRIPTION
## 概要
オートコンプリート機能に2点改善を加えました。

## 1つ目：候補検索を行う最小文字数をコンストラクタから設定可能に変更
以前までのオートコンプリート機能は、インスタンスごとに検索を行う文字数を設定できませんでした。
AutocompleteクラスにminLength引数を追加し、初期化時に最小文字数を設定できるように変更しました。
https://github.com/pubannotation/textae/commit/6f0a58eac1f4ad3e49d5264000581e5131de50e6

## 2つ目：ウィンドウのリサイズに対応
候補リストがウィンドウのリサイズに追従するためのコードを追加しました。
https://github.com/pubannotation/textae/commit/1a1fc0283f5465ffa517694589f39558a01917b9

この変更によって、次のような動作が期待できます。

https://github.com/user-attachments/assets/82dba95e-cd7a-4c7f-a5ce-5e2f9cbc1cd4

ただ、リサイズによる問題はTextAEでは発生していません。オートコンプリート機能はどれもダイアログ内で使っており、ダイアログはリサイズされないためです。
<img width="600" alt="image" src="https://github.com/user-attachments/assets/53e13a54-c5d0-4119-a5b9-6a39310e5cc1">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/97f26937-a6b6-4075-8a17-3f453f187312">


今の所は問題はないのですが、今後ダイアログ外でオートコンプリート機能を使う可能性を考えると、対応しておくべきと思い修正しました。


## 動作確認
通常動作に変更はなく問題ありません。

https://github.com/user-attachments/assets/b80dc16d-a188-4f31-bb00-5fd20261f150