### PR TITLE
Fix InlineTextAnnotation covert problems

### DIFF
--- a/src/lib/Editor/RemoteResource/parseResponse.js
+++ b/src/lib/Editor/RemoteResource/parseResponse.js
@@ -10,11 +10,11 @@ export default function parseResponse(response, url, onLoaded, onFailed) {
         if (annotation) {
           onLoaded(annotation)
         } else {
-          onFailed
+          onFailed()
         }
       })
     })
   } else {
-    onFailed
+    onFailed()
   }
 }

--- a/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile.js
+++ b/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile.js
@@ -24,7 +24,7 @@ export default async function (file, eventEmitter) {
   if (isMdFile(file.name)) {
     const annotation = await convertTextAnnotationToJSON(fileContent)
 
-    if (annotation.text) {
+    if (annotation && annotation.text) {
       eventEmitter.emit(
         'textae-event.resource.annotation.load.success',
         DataSource.createFileSource(file.name, annotation)

--- a/src/lib/Editor/convertTextAnnotationToJSON.js
+++ b/src/lib/Editor/convertTextAnnotationToJSON.js
@@ -13,9 +13,7 @@ export default async function convertTextAnnotationToJSON(text) {
     )
 
     if (!response.ok) {
-      console.error(
-        `Conversion failed: response.status = ${response.status}, response.statusText = ${response.statusText}`
-      )
+      response.text().then((errorMessage) => console.error(`${errorMessage}`))
       return null
     }
 

--- a/src/lib/Editor/convertTextAnnotationToJSON.js
+++ b/src/lib/Editor/convertTextAnnotationToJSON.js
@@ -6,7 +6,8 @@ export default async function convertTextAnnotationToJSON(text) {
         method: 'POST',
         body: text,
         headers: {
-          Accept: 'application/json'
+          'Content-type': 'text/markdown',
+          'Accept': 'application/json'
         }
       }
     )

--- a/src/lib/Editor/convertTextAnnotationToJSON.js
+++ b/src/lib/Editor/convertTextAnnotationToJSON.js
@@ -7,7 +7,7 @@ export default async function convertTextAnnotationToJSON(text) {
         body: text,
         headers: {
           'Content-type': 'text/markdown',
-          'Accept': 'application/json'
+          Accept: 'application/json'
         }
       }
     )


### PR DESCRIPTION
## 概要
InlineTextAnnotationをJSONに変換する機能周りの不具合を修正しました。

## 修正内容
以下の4点について修正を行いました。
- Inline2json API呼び出し時のPOST requestにContent-Typeを設定
- リクエストが200系以外の場合のエラー通知メッセージ内容を変更
- nullに対してメソッド呼び出しを行うエラーを修正
- parseResponse内でのonFailedコールバック関数が正しく呼べていなかった問題を修正

## 各不具合について
### Inline2json API呼び出し時のPOST requestにContent-Typeを設定
以前まではContent-Typeを指定していませんでした。
inline2json APIが指定のContent-Typeを必須とするように変更されたため、合わせて修正しました。
https://github.com/pubannotation/textae/commit/d0e5bbaf4050f737470b533cddbef674b9e0426a

### リクエストが200系以外の場合のエラー通知メッセージ内容を変更
以前まではresponse.statusとresponse.statusTextを返していましたが、これでは400, bad_requestのような出力になりメッセージまで確認できていませんでした。
そもそもレスポンスのHTTP status codeはfetchで200以外が返ると自動的にconsoleに出力されるため、明示的なログ出力としてはエラーメッセージのみを返すように変更しました。
https://github.com/pubannotation/textae/commit/7a6f04cbaae655be9c73a50beb1c72c29f2470c2

|<img width="600" alt="image" src="https://github.com/user-attachments/assets/af273d83-6e9c-484e-a777-25a35dd2fae9" />|
|:-|

### nullに対してメソッド呼び出しを行うエラーを修正
localから読み込む際のコード修正です。
inline2jsonでアノテーションが得られなかった場合にundefined methodエラーが発生していました。
これを修正しました。
https://github.com/pubannotation/textae/commit/8233f530883260fa25cd27a7381413d2858aac33

修正後に正しくエラー処理が行われていることを確認しました。
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/86e76dbf-10f0-497b-901c-0711a0ac0075" />|
|:-|

### parseResponse内でのonFailedコールバック関数が正しく呼べていなかった問題を修正
構文ミスでエラー処理が正しく行われていなかったため、これを修正しました。
https://github.com/pubannotation/textae/commit/4d801fed9c4fdc5e4e9757b0e10a87899330279e

修正後に正しくエラー処理が行われていることを確認しました。
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/b6105f75-64bf-402d-865c-b278b042dd7c" />|
|:-|