### PR TITLE
Add function to preview inline annotation in save dialog

### DIFF
--- a/src/lib/component/SaveAnnotationDialog/bind/createDownloadPathForFormat.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/createDownloadPathForFormat.js
@@ -1,5 +1,5 @@
-import createDownloadPath from '../../../createDownloadPath'
-import convertJSONAnnotationToInline from '../../../../convertJSONAnnotationToInline'
+import createDownloadPath from '../../createDownloadPath'
+import convertJSONAnnotationToInline from '../../../convertJSONAnnotationToInline'
 
 export default async function createDownloadPathForFormat(data, format) {
   if (format === 'json') {

--- a/src/lib/component/SaveAnnotationDialog/bind/downloadAnnotationFile/index.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/downloadAnnotationFile/index.js
@@ -1,4 +1,4 @@
-import createDownloadPathForFormat from './createDownloadPathForFormat'
+import createDownloadPathForFormat from '../createDownloadPathForFormat'
 import downloadAnnotation from './downloadAnnotation'
 
 export default async function downloadAnnotationFile(

--- a/src/lib/component/SaveAnnotationDialog/bind/index.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/index.js
@@ -1,7 +1,7 @@
 import delegate from 'delegate'
-import createDownloadPath from '../../createDownloadPath'
 import enableHTMLElement from '../../enableHTMLElement'
 import downloadAnnotationFile from './downloadAnnotationFile'
+import viewSource from './viewSource'
 
 export default function (
   eventEmitter,
@@ -47,9 +47,9 @@ export default function (
     element,
     '.textae-editor__save-dialog__viewsource-link',
     'click',
-    () => {
-      window.open(createDownloadPath(data), '_blank')
-      eventEmitter.emit('textae-event.resource.annotation.save', data)
+    async () => {
+      const format = getFormat()
+      await viewSource(data, format, eventEmitter)
       closeDialog()
     }
   )

--- a/src/lib/component/SaveAnnotationDialog/bind/viewSource.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/viewSource.js
@@ -1,0 +1,13 @@
+import createDownloadPathForFormat from './createDownloadPathForFormat'
+
+export default async function viewSource(data, format, eventEmitter) {
+  try {
+    const downloadPath = await createDownloadPathForFormat(data, format)
+    window.open(downloadPath, '_blank')
+
+    eventEmitter.emit('textae-event.resource.annotation.save', data)
+  } catch (e) {
+    console.error(e)
+    return
+  }
+}

--- a/src/lib/component/SaveAnnotationDialog/index.js
+++ b/src/lib/component/SaveAnnotationDialog/index.js
@@ -38,7 +38,7 @@ function template(context) {
     <a class="textae-editor__save-dialog__download-link" href="#">Download</a>
   </div>
   <div class="textae-editor__save-dialog__row">
-    <a class="textae-editor__save-dialog__viewsource-link" href="#">Click to see the json source in a new window.</a>
+    <a class="textae-editor__save-dialog__viewsource-link" href="#">Click to see the source in a new window.</a>
   </div>
 </div>
 `


### PR DESCRIPTION
## 概要
アノテーション保存ダイアログのプレビュー機能で、SimpleInlineフォーマットでの表示に対応しました。
ダイアログのFormatラジオボタンの状態によって表示する内容が切り替わるように変更しました。

## 作業内容
- プレビュー機能のInlineフォーマット対応
- プレビューボタンの内容を微修正
  - Click to see the json source ~~~ => Click to see the source ~~~

## 動作確認
### ダイアログ
|<img width="562" alt="image" src="https://github.com/user-attachments/assets/3960e580-f802-4ba7-882b-852c3a37a256" />|
|:-|

### Inlineフォーマットを指定した場合
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/605897af-87a9-449a-9a7e-e9647808d56f" />

### JSONフォーマットを指定した場合 (動作に影響がないか一応確認)
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/cf34bbf1-6e90-44bd-91cf-2e54a7d26054" />
