### PR TITLE
Refactor exception handling on initAnnotation

### DIFF
--- a/src/lib/Editor/StartUpOptions/AnnotationResource.js
+++ b/src/lib/Editor/StartUpOptions/AnnotationResource.js
@@ -32,10 +32,14 @@ export default class AnnotationResource {
   }
 
   async annotation() {
-    if (isJSON(this.#annotation)) {
-      return JSON.parse(this.#annotation)
-    } else {
-      return await AnnotationConverter.inline2json(this.#annotation)
+    try {
+      if (isJSON(this.#annotation)) {
+        return JSON.parse(this.#annotation)
+      } else {
+        return await AnnotationConverter.inline2json(this.#annotation)
+      }
+    } catch {
+      return null
     }
   }
 

--- a/src/lib/Editor/StartUpOptions/index.js
+++ b/src/lib/Editor/StartUpOptions/index.js
@@ -132,7 +132,11 @@ export default class StartUpOptions {
 
   async annotation() {
     if (this.#resource.isLoaded) {
-      return await this.#resource.annotation()
+      try {
+        return await this.#resource.annotation()
+      } catch {
+        return null
+      }
     }
 
     return null

--- a/src/lib/Editor/StartUpOptions/index.js
+++ b/src/lib/Editor/StartUpOptions/index.js
@@ -132,11 +132,7 @@ export default class StartUpOptions {
 
   async annotation() {
     if (this.#resource.isLoaded) {
-      try {
-        return await this.#resource.annotation()
-      } catch {
-        return null
-      }
+      return await this.#resource.annotation()
     }
 
     return null

--- a/src/lib/Editor/UseCase/initAnnotation/index.js
+++ b/src/lib/Editor/UseCase/initAnnotation/index.js
@@ -19,47 +19,43 @@ export default async function (
 ) {
   switch (startUpOptions.resourceType) {
     case RESOURCE_TYPE.QUERY_PARAMETER: {
-      let annotation
-      try {
-        annotation = await startUpOptions.annotation()
-      } catch {
-        alertifyjs.error(`failed to load annotation from query parameter.`)
-        return
-      }
+      const annotation = await startUpOptions.annotation()
 
-      setLoadedAnnotation(
-        DataSource.createParameterSource(annotation),
-        startUpOptions.config,
-        remoteResource,
-        menuState,
-        spanConfig,
-        annotationModel,
-        functionAvailability,
-        originalData
-      )
+      if (annotation) {
+        setLoadedAnnotation(
+          DataSource.createParameterSource(annotation),
+          startUpOptions.config,
+          remoteResource,
+          menuState,
+          spanConfig,
+          annotationModel,
+          functionAvailability,
+          originalData
+        )
+      } else {
+        alertifyjs.error(`failed to load annotation from query parameter.`)
+      }
       break
     }
     case RESOURCE_TYPE.INLINE: {
-      let annotation
-      try {
-        annotation = await startUpOptions.annotation()
-      } catch {
+      const annotation = await startUpOptions.annotation()
+
+      if (annotation) {
+        setLoadedAnnotation(
+          DataSource.createInlineSource(annotation),
+          startUpOptions.config,
+          remoteResource,
+          menuState,
+          spanConfig,
+          annotationModel,
+          functionAvailability,
+          originalData
+        )
+      } else {
         alertifyjs.error(
           `failed to load annotation from directly included in the div element.`
         )
-        return
       }
-
-      setLoadedAnnotation(
-        DataSource.createInlineSource(annotation),
-        startUpOptions.config,
-        remoteResource,
-        menuState,
-        spanConfig,
-        annotationModel,
-        functionAvailability,
-        originalData
-      )
       break
     }
     case RESOURCE_TYPE.REMOTE_URL:

--- a/src/lib/Editor/UseCase/initAnnotation/index.js
+++ b/src/lib/Editor/UseCase/initAnnotation/index.js
@@ -19,41 +19,47 @@ export default async function (
 ) {
   switch (startUpOptions.resourceType) {
     case RESOURCE_TYPE.QUERY_PARAMETER: {
+      let annotation
       try {
-        const annotation = await startUpOptions.annotation()
-        setLoadedAnnotation(
-          DataSource.createParameterSource(annotation),
-          startUpOptions.config,
-          remoteResource,
-          menuState,
-          spanConfig,
-          annotationModel,
-          functionAvailability,
-          originalData
-        )
+        annotation = await startUpOptions.annotation()
       } catch {
         alertifyjs.error(`failed to load annotation from query parameter.`)
+        return
       }
+
+      setLoadedAnnotation(
+        DataSource.createParameterSource(annotation),
+        startUpOptions.config,
+        remoteResource,
+        menuState,
+        spanConfig,
+        annotationModel,
+        functionAvailability,
+        originalData
+      )
       break
     }
     case RESOURCE_TYPE.INLINE: {
+      let annotation
       try {
-        const annotation = await startUpOptions.annotation()
-        setLoadedAnnotation(
-          DataSource.createInlineSource(annotation),
-          startUpOptions.config,
-          remoteResource,
-          menuState,
-          spanConfig,
-          annotationModel,
-          functionAvailability,
-          originalData
-        )
+        annotation = await startUpOptions.annotation()
       } catch {
         alertifyjs.error(
           `failed to load annotation from directly included in the div element.`
         )
+        return
       }
+
+      setLoadedAnnotation(
+        DataSource.createInlineSource(annotation),
+        startUpOptions.config,
+        remoteResource,
+        menuState,
+        spanConfig,
+        annotationModel,
+        functionAvailability,
+        originalData
+      )
       break
     }
     case RESOURCE_TYPE.REMOTE_URL:


### PR DESCRIPTION
## 概要
例外処理の範囲を狭めることで適切な例外のみ処理する形に変更しました。

## 作業内容
- initAnnotation関数の例外処理の範囲修正

## 動作確認
load時のエラーが修正前同様に動くことを確認しました。

### クエリパラメータのエラー
|<img width="1000" alt="image" src="https://github.com/user-attachments/assets/10c9aa29-ad79-4fd8-b57c-f5f1439350ab" />|
|:-|

### divタグ要素のエラー
|<img width="1000" alt="image" src="https://github.com/user-attachments/assets/fdcd5f3e-2c77-43aa-bc70-9c5a667ab3e8" />|
|:-|