### PR TITLE
Show error as toast when download annotation failed

### DIFF
--- a/src/lib/component/SaveAnnotationDialog/bind/downloadAnnotationFile/index.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/downloadAnnotationFile/index.js
@@ -9,13 +9,8 @@ export default async function downloadAnnotationFile(
 ) {
   e.preventDefault()
 
-  try {
-    const downloadPath = await createDownloadPathForFormat(data, format)
-    downloadAnnotation(downloadPath, e.target.previousElementSibling.value)
+  const downloadPath = await createDownloadPathForFormat(data, format)
+  downloadAnnotation(downloadPath, e.target.previousElementSibling.value)
 
-    eventEmitter.emit('textae-event.resource.annotation.save', data)
-  } catch (e) {
-    console.error(e)
-    return
-  }
+  eventEmitter.emit('textae-event.resource.annotation.save', data)
 }

--- a/src/lib/component/SaveAnnotationDialog/bind/index.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/index.js
@@ -38,9 +38,14 @@ export default function (
     'click',
     async (e) => {
       const format = getFormat()
-      await downloadAnnotationFile(e, data, format, eventEmitter)
 
-      closeDialog()
+      try {
+        await downloadAnnotationFile(e, data, format, eventEmitter)
+      } catch (error) {
+        alertify.error(`Failed to download the source as ${format}.`)
+      } finally {
+        closeDialog()
+      }
     }
   )
 

--- a/src/lib/component/SaveAnnotationDialog/bind/index.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/index.js
@@ -42,7 +42,7 @@ export default function (
       try {
         await downloadAnnotationFile(e, data, format, eventEmitter)
       } catch (error) {
-        alertify.error(`Failed to download the source as ${format}.`)
+        alertify.error(`Failed to download the source as ${format} format.`)
       } finally {
         closeDialog()
       }
@@ -59,7 +59,7 @@ export default function (
       try {
         await viewSource(data, format, eventEmitter)
       } catch (error) {
-        alertify.error(`Failed to view the source as ${format}.`)
+        alertify.error(`Failed to view the source as ${format} format.`)
       } finally {
         closeDialog()
       }


### PR DESCRIPTION
## 概要
annotation download失敗時にトーストでエラーメッセージを表示するように変更しました。
|<img width="367" alt="image" src="https://github.com/user-attachments/assets/8e2222d5-50ab-41ed-aaf1-be323a9a9e8f" />|
|:-|