### PR TITLE
Refactor load dialogs

### DIFF
--- a/src/lib/component/LoadAnnotationDialog/index.js
+++ b/src/lib/component/LoadAnnotationDialog/index.js
@@ -7,6 +7,7 @@ import maximizeOverlay from '../maximizeOverlay'
 import revertMaximizeOverlay from '../revertMaximizeOverlay'
 import initJSONEditor from '../initJSONEditor'
 import initInlineEditor from './initInlineEditor'
+import isUserConfirm from '../isUserConfirm'
 
 function template(context) {
   const { url } = context
@@ -61,9 +62,6 @@ function template(context) {
 </div>`
 }
 
-const CONFIRM_DISCARD_CHANGE_MESSAGE =
-  'There is a change that has not been saved. If you procceed now, you will lose it.'
-
 export default class LoadAnnotationDialog extends Dialog {
   constructor(
     title,
@@ -101,16 +99,13 @@ export default class LoadAnnotationDialog extends Dialog {
       }
     )
 
-    const isUserConfirm = () =>
-      !hasChange || window.confirm(CONFIRM_DISCARD_CHANGE_MESSAGE)
-
     // Load from the URL.
     delegate(
       super.el,
       '.textae-editor__load-dialog__url-button',
       'click',
       (e) => {
-        if (isUserConfirm()) {
+        if (isUserConfirm(hasChange)) {
           loadFromServer(e.target.previousElementSibling.value)
         }
         super.close()
@@ -123,7 +118,7 @@ export default class LoadAnnotationDialog extends Dialog {
       '.textae-editor__load-dialog__local-button',
       'click',
       () => {
-        if (isUserConfirm()) {
+        if (isUserConfirm(hasChange)) {
           readFromFile(this._droppedFile)
         }
 
@@ -139,7 +134,7 @@ export default class LoadAnnotationDialog extends Dialog {
         : super.el.querySelector('.textae-editor__load-dialog__textarea').value
       const format = this.#getFormat()
 
-      if (isUserConfirm()) {
+      if (isUserConfirm(hasChange)) {
         readFromText(text, format)
       }
 

--- a/src/lib/component/LoadConfigurationDialog.js
+++ b/src/lib/component/LoadConfigurationDialog.js
@@ -6,6 +6,7 @@ import isJSON from '../isJSON'
 import maximizeOverlay from './maximizeOverlay'
 import revertMaximizeOverlay from './revertMaximizeOverlay'
 import initJSONEditor from './initJSONEditor'
+import isUserConfirm from './isUserConfirm'
 
 function template(context) {
   const { url } = context
@@ -55,9 +56,6 @@ function template(context) {
 </div>`
 }
 
-const CONFIRM_DISCARD_CHANGE_MESSAGE =
-  'There is a change that has not been saved. If you procceed now, you will lose it.'
-
 export default class LoadConfigurationDialog extends Dialog {
   constructor(
     title,
@@ -95,16 +93,13 @@ export default class LoadConfigurationDialog extends Dialog {
       }
     )
 
-    const isUserConfirm = () =>
-      !hasChange || window.confirm(CONFIRM_DISCARD_CHANGE_MESSAGE)
-
     // Load from the URL.
     delegate(
       super.el,
       '.textae-editor__load-dialog__url-button',
       'click',
       (e) => {
-        if (isUserConfirm()) {
+        if (isUserConfirm(hasChange)) {
           loadFromServer(e.target.previousElementSibling.value)
         }
         super.close()
@@ -117,7 +112,7 @@ export default class LoadConfigurationDialog extends Dialog {
       '.textae-editor__load-dialog__local-button',
       'click',
       () => {
-        if (isUserConfirm()) {
+        if (isUserConfirm(hasChange)) {
           readFromFile(this._droppedFile)
         }
 
@@ -131,7 +126,7 @@ export default class LoadConfigurationDialog extends Dialog {
       const text = jsonEditor
         ? jsonEditor.state.doc.toString()
         : super.el.querySelector('.textae-editor__load-dialog__textarea').value
-      if (isUserConfirm()) {
+      if (isUserConfirm(hasChange)) {
         readFromText(text)
       }
 

--- a/src/lib/component/isUserConfirm.js
+++ b/src/lib/component/isUserConfirm.js
@@ -1,0 +1,6 @@
+export default function isUserConfirm(hasChange) {
+  const CONFIRM_DISCARD_CHANGE_MESSAGE =
+    'There is a change that has not been saved. If you proceed now, you will lose it.'
+
+  return !hasChange || window.confirm(CONFIRM_DISCARD_CHANGE_MESSAGE)
+}


### PR DESCRIPTION
## 概要
https://github.com/pubannotation/textae/pull/168#discussion_r1935052220
の対応として、
LoadAnnotationDialogとLoadConfigurationDialogの共通化できる処理を共通化しました。

(コメントで指定されていた処理以外に共通化できそうな処理が見つけられなかったため、指定部分のみの対応を行いました)

## 作業内容
- isUserConfirm定数の共通化

## 動作確認
### confirmが動作していることを確認
|<img width="594" alt="image" src="https://github.com/user-attachments/assets/183758e6-7dc2-4b2c-803e-c571bd13a3eb" />|
|:-|