### PR TITLE
Clean error notification for annotation import and export

### DIFF
--- a/src/lib/Editor/InlineAnnotationConverter.js
+++ b/src/lib/Editor/InlineAnnotationConverter.js
@@ -1,3 +1,5 @@
+import FormatConversionError from '../exceptions/formatConversionError'
+
 export default class InlineAnnotationConverter {
   #url
   constructor(url) {
@@ -15,7 +17,7 @@ export default class InlineAnnotationConverter {
 
     if (!response.ok) {
       const errorMessage = await response.text()
-      throw Error(errorMessage)
+      throw new FormatConversionError(errorMessage)
     }
 
     return await response.json()

--- a/src/lib/Editor/InlineAnnotationConverter.js
+++ b/src/lib/Editor/InlineAnnotationConverter.js
@@ -1,4 +1,4 @@
-import FormatConversionError from '../exceptions/formatConversionError'
+import FormatConversionError from '../exceptions/FormatConversionError'
 
 export default class InlineAnnotationConverter {
   #url

--- a/src/lib/Editor/RemoteResource/AnnotationLoader/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationLoader/index.js
@@ -31,8 +31,7 @@ export default class AnnotationLoader {
       } else {
         this.#failed(url)
       }
-    } catch (e) {
-      console.error(e)
+    } catch {
       this.#failed(url)
     } finally {
       this.#eventEmitter.emit('textae-event.resource.endLoad')
@@ -80,8 +79,7 @@ export default class AnnotationLoader {
       } else {
         this.#failed(url)
       }
-    } catch (e) {
-      console.error(e)
+    } catch {
       this.#failed(url)
     }
   }

--- a/src/lib/Editor/RemoteResource/AnnotationLoader/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationLoader/index.js
@@ -1,6 +1,7 @@
 import alertifyjs from 'alertifyjs'
 import DataSource from '../../DataSource'
 import parseResponse from './parseResponse'
+import FormatConversionError from '../../../exceptions/formatConversionError'
 
 export default class AnnotationLoader {
   #eventEmitter
@@ -31,7 +32,10 @@ export default class AnnotationLoader {
       } else {
         this.#failed(url)
       }
-    } catch {
+    } catch (e) {
+      if (!(e instanceof FormatConversionError)) {
+        console.error(e)
+      }
       this.#failed(url)
     } finally {
       this.#eventEmitter.emit('textae-event.resource.endLoad')

--- a/src/lib/Editor/RemoteResource/AnnotationLoader/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationLoader/index.js
@@ -1,7 +1,7 @@
 import alertifyjs from 'alertifyjs'
 import DataSource from '../../DataSource'
 import parseResponse from './parseResponse'
-import FormatConversionError from '../../../exceptions/formatConversionError'
+import FormatConversionError from '../../../exceptions/FormatConversionError'
 
 export default class AnnotationLoader {
   #eventEmitter

--- a/src/lib/Editor/RemoteResource/AnnotationSaver/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationSaver/index.js
@@ -23,8 +23,7 @@ export default class AnnotationSaver {
       const response = await this.#postTo(url, requestBody)
 
       await this.#processResponse(response, url, editedData)
-    } catch (e) {
-      console.error(e)
+    } catch {
       this.#failed()
     } finally {
       this.#eventEmitter.emit('textae-event.resource.endSave')

--- a/src/lib/Editor/RemoteResource/AnnotationSaver/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationSaver/index.js
@@ -3,7 +3,7 @@ import isServerAuthRequired from '../isServerPageAuthRequired'
 import openPopUp from '../openPopUp'
 import prepareRequestBody from './prepareRequestBody'
 import waitForPopUpClose from './waitForPopUpClose'
-import FormatConversionError from '../../../exceptions/formatConversionError'
+import FormatConversionError from '../../../exceptions/FormatConversionError'
 
 export default class AnnotationSaver {
   #format

--- a/src/lib/Editor/RemoteResource/AnnotationSaver/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationSaver/index.js
@@ -3,6 +3,7 @@ import isServerAuthRequired from '../isServerPageAuthRequired'
 import openPopUp from '../openPopUp'
 import prepareRequestBody from './prepareRequestBody'
 import waitForPopUpClose from './waitForPopUpClose'
+import FormatConversionError from '../../../exceptions/formatConversionError'
 
 export default class AnnotationSaver {
   #format
@@ -23,7 +24,10 @@ export default class AnnotationSaver {
       const response = await this.#postTo(url, requestBody)
 
       await this.#processResponse(response, url, editedData)
-    } catch {
+    } catch (e) {
+      if (!(e instanceof FormatConversionError)) {
+        console.error(e)
+      }
       this.#failed()
     } finally {
       this.#eventEmitter.emit('textae-event.resource.endSave')

--- a/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile/parseMdFile.js
+++ b/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile/parseMdFile.js
@@ -1,0 +1,13 @@
+import InlineAnnotationConverter from '../../../InlineAnnotationConverter'
+
+export default async function parseMdFile(fileContent) {
+  try {
+    const annotation = await new InlineAnnotationConverter(
+      'https://pubannotation.org/conversions/inline2json'
+    ).toJSON(fileContent)
+
+    return annotation
+  } catch {
+    return null
+  }
+}

--- a/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationText.js
+++ b/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationText.js
@@ -22,7 +22,10 @@ export default async function readAnnotationText(eventEmitter, text, format) {
 
       loadAnnotation(eventEmitter, annotation)
     } catch {
-      alertifyjs.error(`Failed to load annotation as inline format.`)
+      const dataSource = DataSource.createInstantSource()
+      alertifyjs.error(
+        `Failed to load annotation from ${dataSource.displayName}.`
+      )
     }
   }
 }

--- a/src/lib/JSONAnnotationConverter.js
+++ b/src/lib/JSONAnnotationConverter.js
@@ -1,3 +1,4 @@
+import FormatConversionError from './exceptions/formatConversionError'
 export default class JSONAnnotationConverter {
   #url
   constructor(url) {
@@ -15,7 +16,7 @@ export default class JSONAnnotationConverter {
 
     if (!response.ok) {
       const errorMessage = await response.text()
-      throw Error(errorMessage)
+      throw new FormatConversionError(errorMessage)
     }
 
     return await response.text()

--- a/src/lib/JSONAnnotationConverter.js
+++ b/src/lib/JSONAnnotationConverter.js
@@ -1,4 +1,5 @@
-import FormatConversionError from './exceptions/formatConversionError'
+import FormatConversionError from './exceptions/FormatConversionError'
+
 export default class JSONAnnotationConverter {
   #url
   constructor(url) {

--- a/src/lib/exceptions/FormatConversionError.js
+++ b/src/lib/exceptions/FormatConversionError.js
@@ -1,0 +1,6 @@
+export default class FormatConversionError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'FormatConversionError'
+  }
+}


### PR DESCRIPTION
## 概要
アノテーションImport/Export機能のエラー通知周りの処理を整理・統一しました。

## 作業内容
- Local import機能でエラー時に例外処理が不足していたため修正
- Convert処理で例外が発生した場合の内容のログ出力はしない形で統一
- エラーメッセージ文の統一

## Local import機能の例外処理について
Local import機能では例外処理が不足していて、Inline変換時に例外が発生するとトーストが出ない、かつ例外がコンソールに表示されていました。
Inline変換に失敗すると適切なエラーメッセージを表示するように修正しました。
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/02be5dc8-2fe9-4666-84e6-9e9852a14fc4" />|
|:-|

##