### PR TITLE
Fix load dialog buttons problem

### DIFF
--- a/src/lib/component/LoadAnnotationDialog/index.js
+++ b/src/lib/component/LoadAnnotationDialog/index.js
@@ -163,11 +163,10 @@ export default class LoadAnnotationDialog extends Dialog {
           : initInlineEditor(textarea, dialogHeight)
 
       // Disable buttons to prevent format change.
-      super.el
-        .querySelectorAll(
-          '.textae-editor__load-dialog__format-button input[type="radio"]'
-        )
-        .forEach((radio) => (radio.disabled = true))
+      const formatButtons = super.el.querySelectorAll(
+        '.textae-editor__load-dialog__format-button input[type="radio"]'
+      )
+      for (const button of formatButtons) button.disabled = true
       // Disable edit button to avoid create multiple editors.
       super.el.querySelector('[type="button"].edit').disabled = true
     })

--- a/src/lib/component/LoadAnnotationDialog/index.js
+++ b/src/lib/component/LoadAnnotationDialog/index.js
@@ -161,6 +161,13 @@ export default class LoadAnnotationDialog extends Dialog {
         format === 'json'
           ? initJSONEditor(textarea, dialogHeight)
           : initInlineEditor(textarea, dialogHeight)
+
+      super.el
+        .querySelectorAll(
+          '.textae-editor__load-dialog__format-button input[type="radio"]'
+        )
+        .forEach((radio) => (radio.disabled = true))
+      super.el.querySelector('[type="button"].edit').disabled = true
     })
   }
 

--- a/src/lib/component/LoadAnnotationDialog/index.js
+++ b/src/lib/component/LoadAnnotationDialog/index.js
@@ -162,11 +162,13 @@ export default class LoadAnnotationDialog extends Dialog {
           ? initJSONEditor(textarea, dialogHeight)
           : initInlineEditor(textarea, dialogHeight)
 
+      // Disable buttons to prevent format change.
       super.el
         .querySelectorAll(
           '.textae-editor__load-dialog__format-button input[type="radio"]'
         )
         .forEach((radio) => (radio.disabled = true))
+      // Disable edit button to avoid create multiple editors.
       super.el.querySelector('[type="button"].edit').disabled = true
     })
   }

--- a/src/lib/component/LoadConfigurationDialog.js
+++ b/src/lib/component/LoadConfigurationDialog.js
@@ -148,6 +148,7 @@ export default class LoadConfigurationDialog extends Dialog {
       ).clientHeight
       jsonEditor = initJSONEditor(textarea, dialogHeight)
 
+      // Disable edit button to avoid create multiple editors.
       super.el.querySelector('[type="button"].edit').disabled = true
     })
   }

--- a/src/lib/component/LoadConfigurationDialog.js
+++ b/src/lib/component/LoadConfigurationDialog.js
@@ -147,6 +147,8 @@ export default class LoadConfigurationDialog extends Dialog {
         '.textae-editor__dialog'
       ).clientHeight
       jsonEditor = initJSONEditor(textarea, dialogHeight)
+
+      super.el.querySelector('[type="button"].edit').disabled = true
     })
   }
 


### PR DESCRIPTION
## 概要
LoadDialogのボタンの問題を修正しました。

## 問題と修正内容
- エディタを起動してからJSONとSimple Inline Text Annotation Formatのラジオボタンを切り替えられる問題
- エディタを複数起動できる問題

この2つの問題に対して、エディタを開いたらフォーマットのラジオボタンとEditボタンをdisabledにすることで対応しました。

## 動作確認
### LoadAnnotationDialog
formatのラジオボタンとEditボタンがdisabledになっていることが確認できます。
|<img width="1891" alt="image" src="https://github.com/user-attachments/assets/82c0472b-157a-46df-b1ac-cb9fb2099e84" />|
|:-|

### LoadConfigurationDialog
Editボタンがdisabledになっていることが確認できます。
|<img width="1888" alt="image" src="https://github.com/user-attachments/assets/b3110491-19fe-4a94-bffe-088f0b6a25c4" />|
|:-|