### PR TITLE
Change expected MIME-type and file extension on SimpleInlineTextAnnotationFormat

### DIFF
--- a/src/lib/Editor/InlineAnnotationConverter.js
+++ b/src/lib/Editor/InlineAnnotationConverter.js
@@ -11,7 +11,7 @@ export default class InlineAnnotationConverter {
       method: 'POST',
       body: inlineAnnotation,
       headers: {
-        'Content-type': 'text/markdown'
+        'Content-type': 'text/plain'
       }
     })
 

--- a/src/lib/Editor/RemoteResource/AnnotationLoader/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationLoader/index.js
@@ -19,7 +19,7 @@ export default class AnnotationLoader {
         cache: 'no-cache',
         credentials: 'omit',
         headers: {
-          Accept: 'application/json, text/markdown'
+          Accept: 'application/json, text/plain'
         },
         signal: AbortSignal.timeout(30000)
       })
@@ -70,7 +70,7 @@ export default class AnnotationLoader {
         cache: 'no-cache',
         credentials: 'include',
         headers: {
-          Accept: 'application/json, text/markdown'
+          Accept: 'application/json, text/plain'
         },
         signal: AbortSignal.timeout(30000)
       })

--- a/src/lib/Editor/RemoteResource/AnnotationLoader/parseResponse/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationLoader/parseResponse/index.js
@@ -1,10 +1,10 @@
-import { isJsonResponse, isMarkdownResponse } from './responseTypes'
+import { isJsonResponse, isTxtResponse } from './responseTypes'
 import InlineAnnotationConverter from '../../../InlineAnnotationConverter'
 
 export default async function parseResponse(response, url) {
   if (isJsonResponse(response, url)) {
     return await response.json()
-  } else if (isMarkdownResponse(response, url)) {
+  } else if (isTxtResponse(response, url)) {
     const inline_annotation = await response.text()
     return await new InlineAnnotationConverter(
       'https://pubannotation.org/conversions/inline2json'

--- a/src/lib/Editor/RemoteResource/AnnotationLoader/parseResponse/responseTypes.js
+++ b/src/lib/Editor/RemoteResource/AnnotationLoader/parseResponse/responseTypes.js
@@ -10,12 +10,12 @@ export function isJsonResponse(response, url) {
   )
 }
 
-export function isMarkdownResponse(response, url) {
+export function isTxtResponse(response, url) {
   const fileExtension = path.extname(url)
   const contentType = response.headers.get('Content-Type')
 
   return (
-    fileExtension === '.md' ||
-    (contentType && contentType.includes('text/markdown'))
+    fileExtension === '.txt' ||
+    (contentType && contentType.includes('text/plain'))
   )
 }

--- a/src/lib/Editor/RemoteResource/AnnotationSaver/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationSaver/index.js
@@ -36,7 +36,7 @@ export default class AnnotationSaver {
 
   async #postTo(url, body) {
     const contentType =
-      this.#format === 'json' ? 'application/json' : 'text/markdown'
+      this.#format === 'json' ? 'application/json' : 'text/plain'
 
     const opt = {
       method: 'POST',


### PR DESCRIPTION
## 概要
SimpleInlineTextAnnotationFormatとして期待するMIME-typeと拡張子を変更しました。
(Localからimportするときの処理のみ、変更を保留しています)

## 作業内容
- SimpleInlineTextAnnotationFormatとして期待するMIME-typeをtext/plainに、拡張子をtxtに変更

## 動作確認
Local読み込み以外のImport/Exportの各機能に対して、SimpleInlineAnnotationを使用する動作に問題がないことを確認しました。

### URL読み込み
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/c5413e91-0f80-4781-af6a-f7b128b0d50a" />|
|:-|

### 直接入力読み込み
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/87a4d638-f338-4a94-b471-93c27824e61d" />|
|:-|

### URL保存
|<img width="1200" alt="image" src="https://github.com/user-attachments/assets/9d28f91b-8531-476d-be0e-514cbc436f99" />|
|:-|

### Local保存
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/08a3375c-dc33-4b79-a738-e670ded3c1e0" />|
|:-|

### プレビュー
|<img width="1200" alt="image" src="https://github.com/user-attachments/assets/ba73b07b-9e81-4670-ae63-b49737505e83" />|
|:-|