### PR TITLE
Add function to edit autocompletion_ws of string attribute definition

### DIFF
--- a/src/lib/component/EditAttributeDefinitionDialog/index.js
+++ b/src/lib/component/EditAttributeDefinitionDialog/index.js
@@ -47,10 +47,18 @@ export default class EditAttributeDefinitionDialog extends PromiseDialog {
           diff.set('default', defaultValue)
         }
 
+        const autocompletionWs = getInputElementValue(
+          super.el,
+          `.${componentClassName}__autocompletion-ws`
+        )
         const mediaHeight = getInputElementValue(
           super.el,
           `.${componentClassName}__media-height`
         )
+
+        if (attrDef.autocompletionWs !== autocompletionWs) {
+          diff.set('autocompletion_ws', autocompletionWs)
+        }
 
         if (attrDef.mediaHeight !== mediaHeight) {
           diff.set('media height', mediaHeight)

--- a/src/lib/component/inputAttributeDefinition/index.js
+++ b/src/lib/component/inputAttributeDefinition/index.js
@@ -1,3 +1,4 @@
+import inputAutocomletionWs from './inputAutocompletionWs'
 import inputDefault from './inputDefault'
 import inputMediaHeight from './inputMediaHeight'
 import inputLabelAndColor from './inputLabelAndColor'
@@ -7,6 +8,7 @@ import anemone from '../anemone'
 export default function (componentClassName, context) {
   const {
     pred,
+    autocompletionWs,
     default: defaultValue,
     mediaHeight,
     label,
@@ -17,6 +19,7 @@ export default function (componentClassName, context) {
     valueType
   } = context
 
+  const showAutocompletionWs = valueType === 'string'
   const showDefault = valueType === 'numeric' || valueType === 'string'
   const showMediaHeight = valueType === 'string'
   const showLabelAndColor = valueType === 'flag'
@@ -30,6 +33,7 @@ export default function (componentClassName, context) {
         class="${componentClassName}__pred textae-editor__promise-dialog__observable-element"
       >
     </div>
+    ${showAutocompletionWs ? inputAutocomletionWs(componentClassName, autocompletionWs) : ''}
     ${showDefault ? inputDefault(componentClassName, defaultValue) : ''}
     ${showMediaHeight ? inputMediaHeight(componentClassName, mediaHeight) : ''}
     ${

--- a/src/lib/component/inputAttributeDefinition/inputAutocompletionWs.js
+++ b/src/lib/component/inputAttributeDefinition/inputAutocompletionWs.js
@@ -1,0 +1,16 @@
+import anemone from '../anemone'
+
+export default function inputAutocomletionWs(
+  componentClassName,
+  autocompletionWs
+) {
+  return () => anemone`
+  <div class="${componentClassName}__row">
+    <label>Autocompletion_ws</label>
+    <input
+      value="${autocompletionWs || ''}"
+      class="${componentClassName}__autocompletion-ws"
+    >
+  </div>
+  `
+}


### PR DESCRIPTION
## 概要
String Attributeのautocompletion_wsを画面で編集する機能を追加しました。

## 作業内容
以下ダイアログにAutocompletion_ws入力欄を追加し、値を変更できるようにしました。
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/f0acea86-19e0-447b-8fe5-e8342fc51afe" />|
|:-|

## 動作確認
ダイアログでの入力が保持されていること、diffに変更が現れていることを確認しました。

https://github.com/user-attachments/assets/fcae4bb9-42b9-4f5b-b79b-a1eb57c57faa

JSONで保存したconfigファイルにも変更が反映されていることを確認しました。
<img width="442" alt="image" src="https://github.com/user-attachments/assets/489dc268-f831-4693-a65d-81d520995cf6" />
