### PR TITLE
Refactor SpanConfig class

### DIFF
--- a/src/lib/Editor/UseCase/SpanConfig.js
+++ b/src/lib/Editor/UseCase/SpanConfig.js
@@ -28,41 +28,44 @@ const defaults = {
 }
 
 export default class SpanConfig {
+  #delimiterCharacters
+  #blankCharacters
+
   constructor() {
-    this._delimiterCharacters = []
-    this._blankCharacters = []
+    this.#delimiterCharacters = []
+    this.#blankCharacters = []
   }
 
   get delimiterCharacters() {
-    return this._delimiterCharacters
+    return this.#delimiterCharacters
   }
 
   get blankCharacters() {
-    return this._blankCharacters
+    return this.#blankCharacters
   }
 
   set(config) {
     const settings = { ...defaults, ...config }
 
-    this._delimiterCharacters = settings['delimiter characters']
-    this._blankCharacters = settings['non-edge characters']
+    this.#delimiterCharacters = settings['delimiter characters']
+    this.#blankCharacters = settings['non-edge characters']
     return config
   }
 
   isDelimiter(char) {
-    if (this._delimiterCharacters.indexOf('ANY') >= 0) {
+    if (this.#delimiterCharacters.indexOf('ANY') >= 0) {
       return 1
     }
 
-    return this._delimiterCharacters.indexOf(char) >= 0
+    return this.#delimiterCharacters.indexOf(char) >= 0
   }
 
   isBlankCharacter(char) {
-    return this._blankCharacters.indexOf(char) >= 0
+    return this.#blankCharacters.indexOf(char) >= 0
   }
 
   removeBlankCharacters(str) {
-    for (const char of this._blankCharacters) {
+    for (const char of this.#blankCharacters) {
       str = str.replaceAll(char, '')
     }
 


### PR DESCRIPTION
## 概要
SpanConfigクラスのプライベートプロパティの定義方法を、_から#を使うように変更しました。

## 動作確認 (一応)
SettingDialogで値が取得できているため動作問題ありません。
|<img width="617" alt="image" src="https://github.com/user-attachments/assets/cb00c113-93a7-49f2-a0a7-9f964af70a1f" />|
|:-|
