### PR TITLE
Change file extension support for simple inline format

### DIFF
--- a/src/lib/Editor/UseCase/PersistenceInterface/isMdFile.js
+++ b/src/lib/Editor/UseCase/PersistenceInterface/isMdFile.js
@@ -1,5 +1,0 @@
-import path from 'path-browserify'
-
-export default function (fileName) {
-  return path.extname(fileName) === '.md'
-}

--- a/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile/index.js
+++ b/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile/index.js
@@ -1,29 +1,18 @@
 import readFile from '../readFile'
 import isJSON from '../../../../isJSON'
 import isTxtFile from '../isTxtFile'
-import isMdFile from '../isMdFile'
 import DataSource from '../../../DataSource'
-import parseMdFile from './parseMdFile'
+import parseFileContent from './parseFileContent'
 import alertifyjs from 'alertifyjs'
 
 export default async function readAnnotationFile(file, eventEmitter) {
   const event = await readFile(file)
   const fileContent = event.target.result
 
+  // SimpleInlineTextAnnotation uses the txt extension.
+  // If this is .txt, parse first and then saving the content.
   if (isTxtFile(file.name)) {
-    // If this is .txt, New annotation json is made from .txt
-    eventEmitter.emit(
-      'textae-event.resource.annotation.load.success',
-      DataSource.createFileSource(file.name, {
-        text: fileContent
-      })
-    )
-
-    return
-  }
-
-  if (isMdFile(file.name)) {
-    const annotation = await parseMdFile(fileContent)
+    const annotation = await parseFileContent(fileContent)
 
     if (!annotation) {
       const dataSource = DataSource.createFileSource(file.name)

--- a/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile/parseFileContent.js
+++ b/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile/parseFileContent.js
@@ -1,6 +1,6 @@
 import InlineAnnotationConverter from '../../../InlineAnnotationConverter'
 
-export default async function parseMdFile(fileContent) {
+export default async function parseFileContent(fileContent) {
   try {
     const annotation = await new InlineAnnotationConverter(
       'https://pubannotation.org/conversions/inline2json'


### PR DESCRIPTION
## 概要
アノテーションのファイル読み込み時にSimpleInlineFormatとして変換する拡張子を変更しました。

## 作業内容
- md拡張子のサポートを削除
- txt拡張子時にinline2json変換処理を実行

## 動作確認
### txtファイルとしてSimpleInlineFormatが読み込めている
使用ファイル
```
[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].

[Person]: https://example.com/Person
[Organization]: https://example.com/Organization
```

|<img width="434" alt="image" src="https://github.com/user-attachments/assets/762196fa-2888-46ba-90ff-35bb61246e52" />|
|:-|

### Inline2JSON通信エラー等の場合
|<img width="1421" alt="image" src="https://github.com/user-attachments/assets/53fe94b1-5582-44c0-ad90-16194f2f5627" />|
|:-|