### PR TITLE
Display validation errors with alertify when adding Delimiter/Non-edge characters

### DIFF
--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/index.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/index.js
@@ -1,6 +1,5 @@
 import anemone from '../../../anemone'
 import validateCharacter from './validateCharacter'
-import alertifyjs from 'alertifyjs'
 
 export default function addCharacterRow(content, type) {
   const input = content.querySelector(
@@ -12,12 +11,8 @@ export default function addCharacterRow(content, type) {
       `.textae-editor__setting-dialog__${type}-character-input`
     )
   ).map((input) => input.value)
-  const errorMessage = validateCharacter(newValue, currentCharacters)
 
-  if (errorMessage) {
-    alertifyjs.warning(`${errorMessage}`)
-    return
-  }
+  if (!validateCharacter(newValue, currentCharacters)) return
 
   const newRow = anemone`
   <tr class="textae-editor__setting-dialog__${type}-character-row">

--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/index.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/index.js
@@ -7,7 +7,12 @@ export default function addCharacterRow(content, type) {
     `.textae-editor__setting-dialog__${type}-character-add-input`
   )
   const newValue = input.value
-  const errorMessage = validateCharacter(content, type, newValue)
+  const currentCharacters = Array.from(
+    content.querySelectorAll(
+      `.textae-editor__setting-dialog__${type}-character-input`
+    )
+  ).map((input) => input.value)
+  const errorMessage = validateCharacter(newValue, currentCharacters)
 
   if (errorMessage) {
     alertifyjs.warning(`${errorMessage}`)

--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/index.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/index.js
@@ -1,4 +1,5 @@
-import anemone from '../../anemone'
+import anemone from '../../../anemone'
+import validateCharacter from './validateCharacter'
 import alertifyjs from 'alertifyjs'
 
 export default function addCharacterRow(content, type) {
@@ -6,16 +7,10 @@ export default function addCharacterRow(content, type) {
     `.textae-editor__setting-dialog__${type}-character-add-input`
   )
   const newValue = input.value
+  const errorMessage = validateCharacter(content, type, newValue)
 
-  const currentCharacters = Array.from(
-    content.querySelectorAll(
-      `.textae-editor__setting-dialog__${type}-character-input`
-    )
-  ).map((input) => input.value)
-
-  // Return with alert when new character already exists.
-  if (currentCharacters.includes(newValue)) {
-    alertifyjs.warning(`${newValue} is already added.`)
+  if (errorMessage) {
+    alertifyjs.warning(`${errorMessage}`)
     return
   }
 

--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
@@ -1,12 +1,16 @@
+import alertifyjs from 'alertifyjs'
+
 export default function validateCharacter(char, currentCharacters) {
   if (currentCharacters.includes(char)) {
-    return `${char} is already added.`
+    alertifyjs.warning(`${char} is already added.`)
+    return false
   }
 
   const decodedChar = char.replace(/\\n/g, '\n')
   if (decodedChar.length > 1) {
-    return `Only one character is allowed.`
+    alertifyjs.warning('Only one character is allowed.')
+    return false
   }
 
-  return null
+  return true
 }

--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
@@ -1,0 +1,18 @@
+export default function validateCharacter(content, type, char) {
+  const decodedChar = char.replace(/\\n/g, '\n')
+  const currentCharacters = Array.from(
+    content.querySelectorAll(
+      `.textae-editor__setting-dialog__${type}-character-input`
+    )
+  ).map((input) => input.value)
+
+  if (currentCharacters.includes(char)) {
+    return `${char} is already added.`
+  }
+
+  if (decodedChar.length > 1) {
+    return `Only one character is allowed.`
+  }
+
+  return null
+}

--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
@@ -1,10 +1,4 @@
-export default function validateCharacter(content, type, char) {
-  const currentCharacters = Array.from(
-    content.querySelectorAll(
-      `.textae-editor__setting-dialog__${type}-character-input`
-    )
-  ).map((input) => input.value)
-
+export default function validateCharacter(char, currentCharacters) {
   if (currentCharacters.includes(char)) {
     return `${char} is already added.`
   }

--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
@@ -1,5 +1,4 @@
 export default function validateCharacter(content, type, char) {
-  const decodedChar = char.replace(/\\n/g, '\n')
   const currentCharacters = Array.from(
     content.querySelectorAll(
       `.textae-editor__setting-dialog__${type}-character-input`
@@ -10,6 +9,7 @@ export default function validateCharacter(content, type, char) {
     return `${char} is already added.`
   }
 
+  const decodedChar = char.replace(/\\n/g, '\n')
   if (decodedChar.length > 1) {
     return `Only one character is allowed.`
   }


### PR DESCRIPTION
## 概要
2文字以上のDelimiter/Non-edge characters追加時にalertifyでwarningを表示するように変更しました。

## 備考
エスケープシーケンスの追加について、\nは追加できるようにしましたが\tは処理全体的に対応できていなかったため、別PRでの対応を行います。

## 動作確認
### 2文字以上のcharacterを追加しようとするとalertifyが出る
\nの追加は可能です。

https://github.com/user-attachments/assets/5e6b7cc7-2e84-4a11-ad2f-da8896724fff

### 既存の重複バリデーションも動作する
|<img width="1022" alt="image" src="https://github.com/user-attachments/assets/191ab5d7-5993-49f8-8b20-2ac7ba5e29a8" />|
|:-|