### PR TITLE
Support tab escape sequence on setting dialog character edit

### DIFF
--- a/src/lib/component/SettingDialog/EscapeSequence.js
+++ b/src/lib/component/SettingDialog/EscapeSequence.js
@@ -1,0 +1,9 @@
+export default class EscapeSequence {
+  static escape(str) {
+    return str.replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/\r/g, '\\r')
+  }
+
+  static decode(str) {
+    return str.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\r/g, '\r')
+  }
+}

--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
@@ -1,4 +1,5 @@
 import alertifyjs from 'alertifyjs'
+import decodeEscapeSequences from '../../decodeEscapeSequences'
 
 export default function validateCharacter(char, currentCharacters) {
   if (currentCharacters.includes(char)) {
@@ -6,8 +7,7 @@ export default function validateCharacter(char, currentCharacters) {
     return false
   }
 
-  const decodedChar = char.replace(/\\n/g, '\n')
-  if (decodedChar.length > 1) {
+  if (decodeEscapeSequences(char).length > 1) {
     alertifyjs.warning('Only one character is allowed.')
     return false
   }

--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/validateCharacter.js
@@ -1,5 +1,5 @@
 import alertifyjs from 'alertifyjs'
-import decodeEscapeSequences from '../../decodeEscapeSequences'
+import EscapeSequence from '../../EscapeSequence'
 
 export default function validateCharacter(char, currentCharacters) {
   if (currentCharacters.includes(char)) {
@@ -7,7 +7,7 @@ export default function validateCharacter(char, currentCharacters) {
     return false
   }
 
-  if (decodeEscapeSequences(char).length > 1) {
+  if (EscapeSequence.decode(char).length > 1) {
     alertifyjs.warning('Only one character is allowed.')
     return false
   }

--- a/src/lib/component/SettingDialog/decodeEscapeSequences.js
+++ b/src/lib/component/SettingDialog/decodeEscapeSequences.js
@@ -1,3 +1,3 @@
 export default function decodeEscapeSequences(str) {
-  return str.replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+  return str.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\r/g, '\r')
 }

--- a/src/lib/component/SettingDialog/decodeEscapeSequences.js
+++ b/src/lib/component/SettingDialog/decodeEscapeSequences.js
@@ -1,3 +1,0 @@
-export default function decodeEscapeSequences(str) {
-  return str.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\r/g, '\r')
-}

--- a/src/lib/component/SettingDialog/decodeEscapeSequences.js
+++ b/src/lib/component/SettingDialog/decodeEscapeSequences.js
@@ -1,0 +1,3 @@
+export default function decodeEscapeSequences(str) {
+  return str.replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+}

--- a/src/lib/component/SettingDialog/saveSpanConfig.js
+++ b/src/lib/component/SettingDialog/saveSpanConfig.js
@@ -1,3 +1,4 @@
+import decodeEscapeSequences from './decodeEscapeSequences'
 import validateConfiguration from './validateConfiguration'
 
 export default function saveSpanConfig(content, spanConfig) {
@@ -7,14 +8,14 @@ export default function saveSpanConfig(content, spanConfig) {
   // Using replace to decode \n.
   // Using reverse to store the added value at the end of the array.
   const newDelimiterCharacters = Array.from(delimiterInputs)
-    .map((input) => input.value.replace(/\\n/g, '\n'))
+    .map((input) => decodeEscapeSequences(input.value))
     .reverse()
 
   const blankInputs = content.querySelectorAll(
     '.textae-editor__setting-dialog__blank-character-input'
   )
   const newBlankCharacters = Array.from(blankInputs)
-    .map((input) => input.value.replace(/\\n/g, '\n'))
+    .map((input) => decodeEscapeSequences(input.value))
     .reverse()
 
   const newSpanConfig = {

--- a/src/lib/component/SettingDialog/saveSpanConfig.js
+++ b/src/lib/component/SettingDialog/saveSpanConfig.js
@@ -1,4 +1,4 @@
-import decodeEscapeSequences from './decodeEscapeSequences'
+import EscapeSequence from './EscapeSequence'
 import validateConfiguration from './validateConfiguration'
 
 export default function saveSpanConfig(content, spanConfig) {
@@ -8,14 +8,14 @@ export default function saveSpanConfig(content, spanConfig) {
   // Using replace to decode \n.
   // Using reverse to store the added value at the end of the array.
   const newDelimiterCharacters = Array.from(delimiterInputs)
-    .map((input) => decodeEscapeSequences(input.value))
+    .map((input) => EscapeSequence.decode(input.value))
     .reverse()
 
   const blankInputs = content.querySelectorAll(
     '.textae-editor__setting-dialog__blank-character-input'
   )
   const newBlankCharacters = Array.from(blankInputs)
-    .map((input) => decodeEscapeSequences(input.value))
+    .map((input) => EscapeSequence.decode(input.value))
     .reverse()
 
   const newSpanConfig = {

--- a/src/lib/component/SettingDialog/saveSpanConfig.js
+++ b/src/lib/component/SettingDialog/saveSpanConfig.js
@@ -5,7 +5,6 @@ export default function saveSpanConfig(content, spanConfig) {
   const delimiterInputs = content.querySelectorAll(
     '.textae-editor__setting-dialog__delimiter-character-input'
   )
-  // Using replace to decode \n.
   // Using reverse to store the added value at the end of the array.
   const newDelimiterCharacters = Array.from(delimiterInputs)
     .map((input) => EscapeSequence.decode(input.value))

--- a/src/lib/component/SettingDialog/template/escapeForDisplay.js
+++ b/src/lib/component/SettingDialog/template/escapeForDisplay.js
@@ -1,10 +1,10 @@
 import escape from 'lodash.escape'
+import EscapeSequence from '../EscapeSequence'
 
 export default function escapeForDisplay(str) {
-  const replaced = str
-    .replace(/\n/g, '\\n')
-    .replace(/\t/g, '\\t')
-    .replace(/\r/g, '\\r')
+  // First, escape newline, tab, and carriage returns to display them.
+  const replaced = EscapeSequence.escape(str)
 
+  // Then, escape special HTML characters to ensure safe rendering in HTML.
   return escape(replaced)
 }

--- a/src/lib/component/SettingDialog/template/escapeForDisplay.js
+++ b/src/lib/component/SettingDialog/template/escapeForDisplay.js
@@ -1,7 +1,10 @@
 import escape from 'lodash.escape'
 
 export default function escapeForDisplay(str) {
-  const replaced = str.replace(/\n/g, '\\n').replace(/\t/g, '\\t')
+  const replaced = str
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t')
+    .replace(/\r/g, '\\r')
 
   return escape(replaced)
 }

--- a/src/lib/component/SettingDialog/template/escapeForDisplay.js
+++ b/src/lib/component/SettingDialog/template/escapeForDisplay.js
@@ -1,7 +1,7 @@
 import escape from 'lodash.escape'
 
 export default function escapeForDisplay(str) {
-  const replaced = str.replace(/\n/g, '\\n')
+  const replaced = str.replace(/\n/g, '\\n').replace(/\t/g, '\\t')
 
   return escape(replaced)
 }


### PR DESCRIPTION
## 概要
SettingDialogでdelimiter/non-edge characterの編集時に`\t`がタブ空白として表示される、かつ2文字以上と判定され追加ができない状態でした。
これを表示と追加ができるように変更しました。

## 作業内容
- \tの表示対応
- \tの追加対応

## 動作確認
### 表示
|<img width="545" alt="image" src="https://github.com/user-attachments/assets/ac48e79c-e677-4162-95bd-e059251e192d" />|
|:-|

### 追加

https://github.com/user-attachments/assets/b39086d9-4765-47c6-94d4-fc2f28d37c82
