### PR TITLE
Display validation error with alertify when edit autocompletion ws

### DIFF
--- a/src/lib/component/SettingDialog/saveAutocompletionWs.js
+++ b/src/lib/component/SettingDialog/saveAutocompletionWs.js
@@ -1,13 +1,20 @@
 import validateConfiguration from './validateConfiguration'
+import alertifyjs from 'alertifyjs'
 
 export default function bindChangeAutocompletionWs(content, typeDictionary) {
   const newValue = content.querySelector(
     '.textae-editor__setting-dialog__autocompletion_ws-text'
   ).value
 
-  validateConfiguration({
+  const errors = validateConfiguration({
     autocompletion_ws: newValue
   })
+
+  if (errors) {
+    alertifyjs.warning(
+      'Saved value of Autocompletion_ws is invalid. Please check the format.'
+    )
+  }
 
   typeDictionary.autocompletionWs = newValue
 }

--- a/src/lib/component/SettingDialog/validateConfiguration.js
+++ b/src/lib/component/SettingDialog/validateConfiguration.js
@@ -9,5 +9,9 @@ const validate = ajv.compile(configurationScheme)
 export default function validateConfiguration(config) {
   if (!validate(config)) {
     console.warn(validate.errors)
+
+    return validate.errors
   }
+
+  return null
 }


### PR DESCRIPTION
## 概要
SettingDialogでAutocompletion_wsの保存時にバリデーションエラーが発生した場合、トーストで内容を通知する処理を追加しました。

## 動作確認
`/dev/autocomplete? order = desc`のような不正なURLを保存すると、開発者ツールへのwarningの表示に加えて通知が出るようになりました。
|<img width="313" alt="image" src="https://github.com/user-attachments/assets/69bd3a93-36c2-447d-9535-fdbb5f07ee75" />|
|:-|
