### PR TITLE
Enable drag selection to span config characters

### DIFF
--- a/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/index.js
+++ b/src/lib/component/SettingDialog/bindAddCharacter/addCharacterRow/index.js
@@ -8,20 +8,16 @@ export default function addCharacterRow(content, type) {
   const newValue = input.value
   const currentCharacters = Array.from(
     content.querySelectorAll(
-      `.textae-editor__setting-dialog__${type}-character-input`
+      `.textae-editor__setting-dialog__${type}-character`
     )
-  ).map((input) => input.value)
+  ).map((span) => span.textContent)
 
   if (!validateCharacter(newValue, currentCharacters)) return
 
   const newRow = anemone`
   <tr class="textae-editor__setting-dialog__${type}-character-row">
     <td>
-      <input
-        class="textae-editor__setting-dialog__${type}-character-input"
-        type="text"
-        value="${newValue}"
-        readonly>
+      <span class="textae-editor__setting-dialog__${type}-character">${newValue}</span>
     </td>
     <td><button class="textae-editor__setting-dialog__${type}-character-delete-button">&times;</button></td>
   </tr>`

--- a/src/lib/component/SettingDialog/saveSpanConfig.js
+++ b/src/lib/component/SettingDialog/saveSpanConfig.js
@@ -3,18 +3,18 @@ import validateConfiguration from './validateConfiguration'
 
 export default function saveSpanConfig(content, spanConfig) {
   const delimiterInputs = content.querySelectorAll(
-    '.textae-editor__setting-dialog__delimiter-character-input'
+    '.textae-editor__setting-dialog__delimiter-character'
   )
   // Using reverse to store the added value at the end of the array.
   const newDelimiterCharacters = Array.from(delimiterInputs)
-    .map((input) => EscapeSequence.decode(input.value))
+    .map((span) => EscapeSequence.decode(span.textContent))
     .reverse()
 
   const blankInputs = content.querySelectorAll(
-    '.textae-editor__setting-dialog__blank-character-input'
+    '.textae-editor__setting-dialog__blank-character'
   )
   const newBlankCharacters = Array.from(blankInputs)
-    .map((input) => EscapeSequence.decode(input.value))
+    .map((span) => EscapeSequence.decode(span.textContent))
     .reverse()
 
   const newSpanConfig = {

--- a/src/lib/component/SettingDialog/template/toBlankCharacterRowElement.js
+++ b/src/lib/component/SettingDialog/template/toBlankCharacterRowElement.js
@@ -4,11 +4,7 @@ export default function toBlankCharacterRowElement(char) {
   return `
 <tr class="textae-editor__setting-dialog__blank-character-row">
   <td>
-    <input
-      type="text"
-      class="textae-editor__setting-dialog__blank-character-input"
-      value="${escapeForDisplay(char)}"
-      readonly>
+    <span class="textae-editor__setting-dialog__blank-character">${escapeForDisplay(char)}</span>
   </td>
   <td><button class="textae-editor__setting-dialog__blank-character-delete-button">&times;</button></td>
 </tr>`

--- a/src/lib/component/SettingDialog/template/toDelimiterCharacterRowElement.js
+++ b/src/lib/component/SettingDialog/template/toDelimiterCharacterRowElement.js
@@ -4,11 +4,7 @@ export default function toDelimiterCharacterRowElement(char) {
   return `
 <tr class="textae-editor__setting-dialog__delimiter-character-row">
   <td>
-    <input
-      type="text"
-      class="textae-editor__setting-dialog__delimiter-character-input"
-      value="${escapeForDisplay(char)}"
-      readonly>
+    <span class="textae-editor__setting-dialog__delimiter-character">${escapeForDisplay(char)}</span>
   </td>
   <td><button class="textae-editor__setting-dialog__delimiter-character-delete-button">&times;</button></td>
 </tr>`

--- a/src/lib/css/textae-editor-dialog.less
+++ b/src/lib/css/textae-editor-dialog.less
@@ -377,12 +377,17 @@
       }
     }
 
-    &__delimiter-character-input {
-      pointer-events: none;
-    }
-
-    &__blank-character-input {
-      pointer-events: none;
+    &__delimiter-character,
+    &__blank-character {
+      display: inline-block;
+      width: 100%;
+      height: 20.5px;
+      line-height: 20.5px;
+      background-color: white;
+      white-space: pre;
+      border: solid 1px rgb(118, 118, 118);
+      border-radius: 2px;
+      padding: 2px;
     }
 
     &__function-availability-list {


### PR DESCRIPTION
## 概要
SettingDialogで表示されるspanConfigのcharacterはドラッグ選択ができず、半角スペース、全角スペースなどの見分けをつけることができませんでした。
この問題を解決するために、ドラッグ選択できるように変更しました。

## 動作確認

https://github.com/user-attachments/assets/1868cf46-0936-433f-8b49-5b3aa8b368f4

