### PR TITLE
Rename format radio button label on SaveAnnotationDialog

### DIFF
--- a/src/lib/component/SaveAnnotationDialog/index.js
+++ b/src/lib/component/SaveAnnotationDialog/index.js
@@ -13,7 +13,7 @@ function template(context) {
         <input type="radio" name="format" value="json" checked>JSON
       </label>
       <label class="textae-editor__save-dialog__format-button">
-        <input type="radio" name="format" value="inline">Inline
+        <input type="radio" name="format" value="inline">Text
       </label>
     </div>
   </div>


### PR DESCRIPTION
## 概要
SaveAnnotationDialog Format指定のラジオボタン名をInlineからTextに修正しました。

## 動作確認
ラベル名のみの変更なので動作に影響はないはずですが、一応URL export/Local export/Preview機能について動作を確認しました。

### URL export
URL出力機能はwebhookで確認し、問題なく動作していました。
<img width="789" alt="image" src="https://github.com/user-attachments/assets/672de788-54bf-49b6-924d-3b89aef20f0c" />

### Local export
ダウンロード機能問題なく動作しました。
|<img width="606" alt="image" src="https://github.com/user-attachments/assets/8da5f28b-6f34-41a8-8943-e838ab1787ad" />|
|:-|

### Preview
Preview機能問題なく動作しました。
<img width="612" alt="image" src="https://github.com/user-attachments/assets/deb850b9-5979-4742-ac21-2f5cc9ffc553" />