### PR TITLE
Fix problem that japanese strings corrupted when preview save annotation

### DIFF
--- a/src/lib/component/SaveAnnotationDialog/bind/createDownloadPathForFormat.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/createDownloadPathForFormat.js
@@ -9,7 +9,7 @@ export default async function createDownloadPathForFormat(data, format) {
       'https://pubannotation.org/conversions/json2inline'
     ).toInline(data)
 
-    const blob = new Blob([inlineData], { type: 'text/plain' })
+    const blob = new Blob([inlineData], { type: 'text/plain;charset=utf-8' })
     return URL.createObjectURL(blob)
   }
 }


### PR DESCRIPTION
## 概要
アノテーション保存時のプレビュー機能にて、日本語の文字またはアノテーションが化けてしまう問題がありました。
この問題を修正しました。

## 動作確認
確認用のアノテーション
|<img width="325" alt="image" src="https://github.com/user-attachments/assets/6b4da871-0f15-491a-ba13-d40844a2249a" />|
|:-|

### 修正前
|<img width="609" alt="image" src="https://github.com/user-attachments/assets/01b67ca2-69d1-4c16-9b1f-f413c52740e7" />|
|:-|

### 修正後
|<img width="639" alt="image" src="https://github.com/user-attachments/assets/82ce6be7-841d-4466-bfdd-059bc8760f51" />|
|:-|

### 修正後 (英語の文章にも影響がない)
|<img width="622" alt="image" src="https://github.com/user-attachments/assets/10bb057b-c866-4ca7-a1b2-8a4015602589" />|
|:-|
