### PR TITLE
Update simple-inline-text-annotation dependency to version 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "observ": "0.2.0",
         "path-browserify": "1.0.1",
         "popover-autocomplete": "^1.0.1",
-        "simple-inline-text-annotation": "^1.0.0",
+        "simple-inline-text-annotation": "^1.1.0",
         "sticky-js": "1.3.0",
         "throttleit": "^2.1.0",
         "uuid": "^11.1.0"
@@ -9198,9 +9198,9 @@
       }
     },
     "node_modules/simple-inline-text-annotation": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-inline-text-annotation/-/simple-inline-text-annotation-1.0.0.tgz",
-      "integrity": "sha512-eaW1Zk4rDGU5/3WdJdVbQ3tcwAsT6caUMAIW2LMqah478P0CKcdF0+sgoss82meD382s1dEqIfsdN9UbsFZPnA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/simple-inline-text-annotation/-/simple-inline-text-annotation-1.1.0.tgz",
+      "integrity": "sha512-NbUiRHTGhpKsR0Sv9woPESaioPCsb2eP6eW50yFaowIVcFKfE89Eel+oowknBfAipgJJZkORtNq3ORq2gPkbSQ==",
       "license": "MIT"
     },
     "node_modules/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "observ": "0.2.0",
     "path-browserify": "1.0.1",
     "popover-autocomplete": "^1.0.1",
-    "simple-inline-text-annotation": "^1.0.0",
+    "simple-inline-text-annotation": "^1.1.0",
     "sticky-js": "1.3.0",
     "throttleit": "^2.1.0",
     "uuid": "^11.1.0"


### PR DESCRIPTION
## 関連issue
https://github.com/Tamada-Arino/simple-inline-text-annotation/issues/28

## 概要

リレーション記法に対応したsimple-inline-text-annotationのバージョン(1.1.0)を指定して、適用させました。

## 動作確認

- 動作確認のため、dev/development.htmlで、simple-inline-text-annotationを使用している箇所の記述をリレーション記法に対応させました。
<img width="877" alt="スクリーンショット 2025-05-08 13 38 50" src="https://github.com/user-attachments/assets/949ef1f4-72f9-4ae3-a051-096c240d10cd" />

- ローカルで確認時、意図通りの表示になっていることを確認しました。
<img width="714" alt="スクリーンショット 2025-05-08 13 39 08" src="https://github.com/user-attachments/assets/9fa48a38-84e5-4737-a9f2-a5ddeeb9bbe5" />

- Text形式でダウンロードを試みた時、出力されたテキストがリレーション記法になっていることを確認しました。
<img width="630" alt="スクリーンショット 2025-05-08 13 48 24" src="https://github.com/user-attachments/assets/83642b8d-2e31-484a-9fe2-e130d870f499" />

[fc2d1193-a329-45af-8bd5-47e28238fa61.txt](https://github.com/user-attachments/files/20097013/fc2d1193-a329-45af-8bd5-47e28238fa61.txt)
