### PR TITLE
Npm package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ To install the package, run the following command:
 ```bash
 npm install textae
 ```
+#### How to Use in HTML
+To use TextAE in your HTML, follow these steps:
+
+1. Include the stylesheet and script
+
+Add the following lines to your `<head>` section to load the TextAE CSS and JS from your `node_modules` directory:
+
+```html
+<link rel="stylesheet" href="node_modules/textae/dist/lib/css/textae-13.9.0.min.css">
+<script src="node_modules/textae/dist/lib/textae-13.9.0.min.js"></script>
+```
+2. Prepare the container
+Add a `<div>` element with the class `textae-editor` to your HTML.
+This is the element where the TextAE editor will be rendered.
+
+```html
+<div class="textae-editor" title="Example Editor" mode="edit"></div>
+```
 
 #### Example HTML
 Here is an example of how to use textae in an HTML file:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,37 @@ http://textae.pubannotation.org/
 Usage
 -----
 
+### Using as an npm package
+
+You can also use `textae` as an npm package in your project.
+
+#### Installation
+
+To install the package, run the following command:
+
+```bash
+npm install textae
+```
+
+#### Example HTML
+Here is an example of how to use textae in an HTML file:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TextAE Example</title>
+  <link rel="stylesheet" href="node_modules/textae/dist/lib/css/textae-13.9.0.min.css">
+  <script src="node_modules/textae/dist/lib/textae-13.9.0.min.js"></script>
+</head>
+<body>
+  <div class="textae-editor" title="Example Editor" mode="edit"></div>
+</body>
+</html>
+```
+
 ## parameters
 
 This editor is customizable by html attributes.

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     ]
   },
   "main": "src/development.html",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/pubannotation/textae.git"


### PR DESCRIPTION
## 概要

npmパッケージとして公開できるようにpackage.jsonの`private: true`の記述を削除しました。
READMEにnpmパッケージとして使用するための記述を追加しました。

## 動作確認

適当な動作確認用のファイルを作成し、ローカルのtextaeをパッケージとしてinstallしました。
動作確認用にindex.htmlを作成し、READMEに追記したとおりに書くとエディタとして利用できることを確認しました。
<img width="751" alt="スクリーンショット 2025-05-09 9 30 05" src="https://github.com/user-attachments/assets/18a31570-bdf4-42c2-b6e3-c158337f2dec" />

<img width="879" alt="スクリーンショット 2025-05-09 9 29 16" src="https://github.com/user-attachments/assets/641a8ee5-9ad7-4e79-b7a8-3e60daa4e7e9" />
