### PR TITLE
Enhancements autocomplete api

### DIFF
--- a/dev/development.html
+++ b/dev/development.html
@@ -311,6 +311,10 @@
             // Focus on the annotation specified by the ID.
             editor.focusDenotation('T1')
 
+            // Set a callback function for autocomplete suggestions.
+            // This function receives the input string `term` and returns a JSON string
+            // of candidate objects whose label includes the given term.
+            // The returned JSON is used by the TextAE editor's autocomplete feature.
             editor.autocompletionCallback = (term) => {
                 const rawData = [
                     {

--- a/dev/development.html
+++ b/dev/development.html
@@ -310,6 +310,25 @@
 
             // Focus on the annotation specified by the ID.
             editor.focusDenotation('T1')
+
+            editor.autocompletionCallback = (term) => {
+                const rawData = [
+                    {
+                        id: 'http://dbpedia.org/ontology/super_long_long_name_items/parent0',
+                        label: 'parent0'
+                    },
+                    {
+                        id: 'http://dbpedia.org/ontology/parent1',
+                        label: 'parent1'
+                    },
+                    {
+                        id: 'http://dbpedia.org/ontology/parent2',
+                        label: 'parent2'
+                    }
+                ]
+
+                return JSON.stringify(rawData.filter((d) => d.label.includes(term)))
+            }
         }
     </script>
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/BlockEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/BlockEditMode/index.js
@@ -18,6 +18,7 @@ export default class BlockEditMode extends EditMode {
   #selectionModel
   #menuState
   #pallet
+  #autocompletionCallbackGetter
 
   constructor(
     editorHTMLElement,
@@ -27,12 +28,15 @@ export default class BlockEditMode extends EditMode {
     spanConfig,
     commander,
     menuState,
-    mousePoint
+    mousePoint,
+    autocompletionCallbackGetter
   ) {
     super()
 
     const getAutocompletionWs = () =>
       annotationModel.typeDictionary.autocompletionWs
+
+    this.#autocompletionCallbackGetter = autocompletionCallbackGetter
 
     this.#pallet = PalletFactory.create(
       editorHTMLElement,
@@ -78,7 +82,8 @@ export default class BlockEditMode extends EditMode {
       annotationModel.typeDictionary.block,
       annotationModel,
       'Entity',
-      getAutocompletionWs
+      getAutocompletionWs,
+      this.#autocompletionCallbackGetter
     )
     this.#selectionModel = selectionModel
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/EditMode/PropertyEditor.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/EditMode/PropertyEditor.js
@@ -10,6 +10,7 @@ export default class PropertyEditor {
   #annotationModel
   #annotationType
   #getAutocompletionWs
+  #autocompletionCallbackGetter
 
   constructor(
     editorHTMLElement,
@@ -20,7 +21,8 @@ export default class PropertyEditor {
     definitionContainer,
     annotationModel,
     annotationType,
-    getAutocompletionWs
+    getAutocompletionWs,
+    autocompletionCallbackGetter
   ) {
     this.#editorHTMLElement = editorHTMLElement
     this.#commander = commander
@@ -31,6 +33,7 @@ export default class PropertyEditor {
     this.#annotationModel = annotationModel
     this.#annotationType = annotationType
     this.#getAutocompletionWs = getAutocompletionWs
+    this.#autocompletionCallbackGetter = autocompletionCallbackGetter
   }
 
   startEditing(selectionModel) {
@@ -64,7 +67,8 @@ export default class PropertyEditor {
       this.#getAutocompletionWs(),
       selectedItems,
       this.#pallet,
-      this.#mousePoint
+      this.#mousePoint,
+      this.#autocompletionCallbackGetter
     )
   }
 }

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/RelationEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/RelationEditMode/index.js
@@ -19,7 +19,8 @@ export default class RelationEditMode extends EditMode {
     selectionModel,
     commander,
     menuState,
-    mousePoint
+    mousePoint,
+    autocompletionCallbackGetter
   ) {
     super()
 
@@ -61,7 +62,8 @@ export default class RelationEditMode extends EditMode {
       annotationModel.typeDictionary.relation,
       annotationModel,
       'Relation',
-      getAutocompletionWs
+      getAutocompletionWs,
+      autocompletionCallbackGetter
     )
     this.#selectionModel = selectionModel
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/TermEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/TermEditMode/index.js
@@ -27,7 +27,8 @@ export default class TermEditMode extends EditMode {
     commander,
     menuState,
     spanConfig,
-    mousePoint
+    mousePoint,
+    autocompletionCallbackGetter
   ) {
     super()
 
@@ -78,7 +79,8 @@ export default class TermEditMode extends EditMode {
       annotationModel.typeDictionary.denotation,
       annotationModel,
       'Denotation',
-      getAutocompletionWs
+      getAutocompletionWs,
+      autocompletionCallbackGetter
     )
     this.#selectionModel = selectionModel
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
@@ -29,7 +29,8 @@ export default class EditModeSwitch {
     menuState,
     startUpOptions,
     mousePoint,
-    editModeState
+    editModeState,
+    autocompletionCallbackGetter
   ) {
     this.#termEditMode = new TermEditMode(
       editorHTMLElement,
@@ -39,7 +40,8 @@ export default class EditModeSwitch {
       commander,
       menuState,
       spanConfig,
-      mousePoint
+      mousePoint,
+      autocompletionCallbackGetter
     )
 
     this.#blockEditMode = new BlockEditMode(
@@ -50,7 +52,8 @@ export default class EditModeSwitch {
       spanConfig,
       commander,
       menuState,
-      mousePoint
+      mousePoint,
+      autocompletionCallbackGetter
     )
 
     this.#relationEditMode = new RelationEditMode(
@@ -60,7 +63,8 @@ export default class EditModeSwitch {
       selectionModel,
       commander,
       menuState,
-      mousePoint
+      mousePoint,
+      autocompletionCallbackGetter
     )
 
     this.#textEditMode = new TextEditMode(

--- a/src/lib/Editor/UseCase/Presenter/index.js
+++ b/src/lib/Editor/UseCase/Presenter/index.js
@@ -38,7 +38,8 @@ export default class Presenter {
     menuState,
     startUpOptions,
     mousePoint,
-    editModeState
+    editModeState,
+    autocompletionCallbackGetter
   ) {
     const editModeSwitch = new EditModeSwitch(
       editorHTMLElement,
@@ -50,7 +51,8 @@ export default class Presenter {
       menuState,
       startUpOptions,
       mousePoint,
-      editModeState
+      editModeState,
+      autocompletionCallbackGetter
     )
 
     eventEmitter

--- a/src/lib/Editor/UseCase/index.js
+++ b/src/lib/Editor/UseCase/index.js
@@ -37,7 +37,8 @@ export default class UseCase {
     eventEmitter,
     annotationModel,
     startUpOptions,
-    selectionModel
+    selectionModel,
+    autocompletionCallbackGetter
   ) {
     const spanConfig = new SpanConfig()
 
@@ -96,7 +97,8 @@ export default class UseCase {
       menuState,
       startUpOptions,
       mousePoint,
-      editModeState
+      editModeState,
+      autocompletionCallbackGetter
     )
     this.#presenter = presenter
     this.#annotationModel = annotationModel

--- a/src/lib/Editor/index.js
+++ b/src/lib/Editor/index.js
@@ -23,6 +23,7 @@ export default class Editor {
   #lastSelectedDenotationIDCallback
   #scrollEventListeners
   #useCase
+  #autocompletionCallbackGetter = null
 
   constructor(
     element,
@@ -88,7 +89,8 @@ export default class Editor {
       eventEmitter,
       annotationModel,
       startUpOptions,
-      selectionModel
+      selectionModel,
+      () => this.getAutocompletionCallback()
     )
     this.#useCase = useCase
 
@@ -145,6 +147,17 @@ export default class Editor {
         callback
       )
     }
+  }
+
+  setAutocompletionCallback(callback) {
+    this.#autocompletionCallbackGetter = callback
+  }
+
+  getAutocompletionCallback() {
+    if (typeof this.#autocompletionCallbackGetter === 'function') {
+      return this.#autocompletionCallbackGetter
+    }
+    return null
   }
 
   get HTMLElementID() {

--- a/src/lib/component/EditPropertiesDialog/index.js
+++ b/src/lib/component/EditPropertiesDialog/index.js
@@ -14,6 +14,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
   #typeName
   #typeLabel
   #attributes
+  #autocompletionCallbackGetter
 
   constructor(
     editorHTMLElement,
@@ -24,7 +25,8 @@ export default class EditPropertiesDialog extends PromiseDialog {
     autocompletionWs,
     selectedItems,
     typeValuesPallet,
-    mousePoint
+    mousePoint,
+    autocompletionCallbackGetter
   ) {
     const { typeName, attributes } = mergedTypeValuesOf(selectedItems)
     const typeLabel = definitionContainer.getLabel(typeName)
@@ -50,6 +52,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
     this.#attributeContainer = attributeContainer
     this.#definitionContainer = definitionContainer
     this.#autocompletionWs = autocompletionWs
+    this.#autocompletionCallbackGetter = autocompletionCallbackGetter
     const updateDisplay = (typeName, label, attributes) => {
       this.#typeName = typeName
       this.#typeLabel = label
@@ -138,6 +141,15 @@ export default class EditPropertiesDialog extends PromiseDialog {
     )
   }
 
+  resolveAutocompleteCandidate(term) {
+    const callback = this.#autocompletionCallbackGetter(term)
+
+    if (typeof callback === 'function') {
+      return callback(term)
+    }
+    return null
+  }
+
   #setupAutocomplete(autocompletionWs, definitionContainer) {
     const typeNameElement = super.el.querySelector(
       '.textae-editor__edit-type-values-dialog__type-name'
@@ -148,13 +160,20 @@ export default class EditPropertiesDialog extends PromiseDialog {
 
     new Autocomplete({
       inputElement: typeNameElement,
-      onSearch: (term, onResult) =>
-        searchTerm(
-          term,
-          onResult,
-          autocompletionWs,
-          definitionContainer.findByLabel(term)
-        ),
+      onSearch: (term, onResult) => {
+        const result = this.resolveAutocompleteCandidate(term)
+
+        if (result !== null && result !== undefined) {
+          onResult(JSON.parse(result))
+        } else {
+          searchTerm(
+            term,
+            onResult,
+            autocompletionWs,
+            definitionContainer.findByLabel(term)
+          )
+        }
+      },
       onSelect: (result) => {
         typeNameElement.value = result.id
         typeLabelElement.innerText = result.label

--- a/src/lib/textae/API.js
+++ b/src/lib/textae/API.js
@@ -19,6 +19,10 @@ export default class API {
     this._editor.setLastSelectedDenotationIDCallback(callback)
   }
 
+  set autocompletionCallback(callback) {
+    this._editor.setAutocompletionCallback(callback)
+  }
+
   get id() {
     return this._editor.HTMLElementID
   }


### PR DESCRIPTION
## 概要

htmlファイルのscriptタグ内で定義した関数を利用して、オートコンプリート機能で出力する候補を設定できるようにしました。

例）
```html
    </script>
        function initializeTextAE() {

            const editor = window.initializeTextAEEditor()
                .find((editor) => editor.id === 'my_text-ae_editor')

            editor.autocompletionCallback = (term) => {
                const rawData = [
                    {
                        id: 'http://dbpedia.org/ontology/super_long_long_name_items/parent0',
                        label: 'parent0'
                    },
                    {
                        id: 'http://dbpedia.org/ontology/parent1',
                        label: 'parent1'
                    },
                    {
                        id: 'http://dbpedia.org/ontology/parent2',
                        label: 'parent2'
                    }
                ]

                return JSON.stringify(rawData.filter((d) => d.label.includes(term)))
            }
        }
    </script>
```

## 動作確認

development.hymlでidが`my_text-ae_editor`のエディタに`autocompletionCallback`を設定しました。
`my_text-ae_editor`idのエディタでオートコンプリートが使用できることを確認しました。

<img width="971" alt="スクリーンショット 2025-05-13 9 46 12" src="https://github.com/user-attachments/assets/e90b434c-f98a-41e1-a36a-4dc1661add44" />

https://github.com/user-attachments/assets/976f2091-eaee-4d1e-ba19-bfeb19e27733

既存のダイアログが意図通り動作することを確認しました。
<img width="1352" alt="スクリーンショット 2025-05-15 14 31 03" src="https://github.com/user-attachments/assets/432245a0-42fb-4b7b-b70c-e3bd027986b8" />
<img width="1399" alt="スクリーンショット 2025-05-15 14 31 18" src="https://github.com/user-attachments/assets/87623f74-36d4-42df-9450-018ac02fc093" />
