### PR TITLE
Use search by label in dialogs

### DIFF
--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -4,6 +4,7 @@ import sortByCountAndName from './sortByCountAndName'
 import countUsage from './countUsage'
 import DefinedType from '../DefinedType'
 import DefinedTypeContainer from './DefinedTypeContainer'
+import searchTerm from '../../../component/searchTerm'
 
 export default class DefinitionContainer {
   #eventEmitter
@@ -140,6 +141,10 @@ export default class DefinitionContainer {
 
   getURI(id) {
     return getUrlMatches(id) ? id : undefined
+  }
+
+  searchByLabel(term, done, autocompletionWs) {
+    searchTerm(term, done, autocompletionWs, this.findByLabel(term))
   }
 
   findByLabel(term) {

--- a/src/lib/component/EditPropertiesDialog/index.js
+++ b/src/lib/component/EditPropertiesDialog/index.js
@@ -4,7 +4,6 @@ import getValues from './getValues'
 import Autocomplete from 'popover-autocomplete'
 import createContentHTML from './createContentHTML'
 import mergedTypeValuesOf from './mergedTypeValuesOf'
-import searchTerm from '../searchTerm'
 import EditAttributeButtonHandler from './EditAttributeButtonHandler'
 
 export default class EditPropertiesDialog extends PromiseDialog {
@@ -149,12 +148,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
     new Autocomplete({
       inputElement: typeNameElement,
       onSearch: (term, onResult) =>
-        searchTerm(
-          term,
-          onResult,
-          autocompletionWs,
-          definitionContainer.findByLabel(term)
-        ),
+        definitionContainer.searchByLabel(term, onResult, autocompletionWs),
       onSelect: (result) => {
         typeNameElement.value = result.id
         typeLabelElement.innerText = result.label

--- a/src/lib/component/TypeDefinitionDialog/index.js
+++ b/src/lib/component/TypeDefinitionDialog/index.js
@@ -1,5 +1,4 @@
 import PromiseDialog from '../PromiseDialog'
-import searchTerm from '../searchTerm'
 import Autocomplete from 'popover-autocomplete'
 import template from './template'
 
@@ -23,12 +22,7 @@ export default class TypeDefinitionDialog extends PromiseDialog {
 
     const [idElement, labelElement] = super.el.querySelectorAll('input')
     const onSearch = (term, onResult) =>
-      searchTerm(
-        term,
-        onResult,
-        autocompletionWs,
-        definitionContainer.findByLabel(term)
-      )
+      definitionContainer.searchByLabel(term, onResult, autocompletionWs)
 
     const onSelect = (result) => {
       idElement.value = result.id


### PR DESCRIPTION
## 概要

DefinitionContainerクラスにsearchByLabelメソッドを作成しました。
既存のEditPropertiesDialogクラスとTypeDefinitionDialogクラスで、searchTermを呼び出している部分を上記のsearchByLabelメソッドに置き換えました。

## 動作確認

EditPropertiesDialogとTypeDefinitionDialogで、それぞれオートコンプリート機能が使用できることを確認しました。

<img width="949" alt="スクリーンショット 2025-05-13 16 50 11" src="https://github.com/user-attachments/assets/da7f85d0-02d0-48a2-a85b-452bbcfcecd4" />


<img width="1017" alt="スクリーンショット 2025-05-14 9 02 19" src="https://github.com/user-attachments/assets/93ff84d0-1b7e-459b-a373-2d25b8a28ae5" />
