### PR TITLE
Make autocompletionWs a private property with getter in TypeDictionary

### DIFF
--- a/src/lib/Editor/AnnotationModel/TypeDictionary.js
+++ b/src/lib/Editor/AnnotationModel/TypeDictionary.js
@@ -33,6 +33,10 @@ export default class TypeDictionary {
     this.#lockStateObservable.set(configLocked)
   }
 
+  set autocompletionWs(value) {
+    this.#autocompletionWs = value
+  }
+
   get denotation() {
     return this.#denotationContainer
   }

--- a/src/lib/Editor/AnnotationModel/TypeDictionary.js
+++ b/src/lib/Editor/AnnotationModel/TypeDictionary.js
@@ -6,6 +6,7 @@ export default class TypeDictionary {
   #blockContainer
   #relationContainer
   #attributeContainer
+  #autocompletionWs
   #lockStateObservable = new Observable(false)
 
   /**
@@ -48,6 +49,10 @@ export default class TypeDictionary {
     return this.#attributeContainer
   }
 
+  get autocompletionWs() {
+    return this.#autocompletionWs
+  }
+
   get config() {
     const ret = {}
 
@@ -87,13 +92,13 @@ export default class TypeDictionary {
       this.#relationContainer.config = config['relation types']
       this.#attributeContainer.config = config['attribute types']
       this.#blockContainer.config = config['block types']
-      this.autocompletionWs = config['autocompletion_ws']
+      this.#autocompletionWs = config['autocompletion_ws']
     } else {
       this.#denotationContainer.config = null
       this.#relationContainer.config = null
       this.#attributeContainer.config = null
       this.#blockContainer.config = null
-      this.autocompletionWs = ''
+      this.#autocompletionWs = ''
     }
 
     this.#eventEmitter.emit(`textae-event.type-definition.reset`)


### PR DESCRIPTION
## 概要

TypeDictionaryのautocopletionWsをプライベートなプロパティとゲッターに修正しました。
autocopletionWsのセッターを作成しました。


## 動作確認

オートコンプリート機能に問題ないことを確認しました
<img width="947" alt="スクリーンショット 2025-05-14 11 31 21" src="https://github.com/user-attachments/assets/46f77a05-9add-4ae1-81ed-6210594983e9" />
