### PR TITLE
Definitioncontainer use typedictionary autocompletionws

### DIFF
--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -14,12 +14,20 @@ export default class DefinitionContainer {
   #getAllInstanceFunc
   #defaultColor
   #defaultType
+  #autocompletionWs
 
-  constructor(eventEmitter, annotationType, getAllInstanceFunc, defaultColor) {
+  constructor(
+    eventEmitter,
+    annotationType,
+    getAllInstanceFunc,
+    defaultColor,
+    autocompletionWs
+  ) {
     this.#eventEmitter = eventEmitter
     this.#annotationType = annotationType
     this.#getAllInstanceFunc = getAllInstanceFunc
     this.#defaultColor = defaultColor
+    this.#autocompletionWs = autocompletionWs
   }
 
   get annotationType() {
@@ -143,8 +151,8 @@ export default class DefinitionContainer {
     return getUrlMatches(id) ? id : undefined
   }
 
-  searchByLabel(term, done, autocompletionWs) {
-    searchTerm(term, done, autocompletionWs, this.findByLabel(term))
+  searchByLabel(term, done) {
+    searchTerm(term, done, this.#autocompletionWs(), this.findByLabel(term))
   }
 
   findByLabel(term) {

--- a/src/lib/Editor/AnnotationModel/index.js
+++ b/src/lib/Editor/AnnotationModel/index.js
@@ -49,7 +49,8 @@ export default class AnnotationModel {
       eventEmitter,
       'relation',
       () => this.#relationInstanceContainer.all,
-      '#00CC66'
+      '#00CC66',
+      () => this.#typeDictionary?.autocompletionWs
     )
 
     this.#relationInstanceContainer = new RelationInstanceContainer(
@@ -111,13 +112,15 @@ export default class AnnotationModel {
       eventEmitter,
       'entity',
       () => this.#entityInstanceContainer.denotations,
-      '#77DDDD'
+      '#77DDDD',
+      () => this.#typeDictionary?.autocompletionWs
     )
     const blockDefinitionContainer = new DefinitionContainer(
       eventEmitter,
       'entity',
       () => this.#entityInstanceContainer.blocks,
-      '#77DDDD'
+      '#77DDDD',
+      () => this.#typeDictionary?.autocompletionWs
     )
     this.#typeDictionary = new TypeDictionary(
       eventEmitter,

--- a/src/lib/component/EditPropertiesDialog/index.js
+++ b/src/lib/component/EditPropertiesDialog/index.js
@@ -148,7 +148,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
     new Autocomplete({
       inputElement: typeNameElement,
       onSearch: (term, onResult) =>
-        definitionContainer.searchByLabel(term, onResult, autocompletionWs),
+        definitionContainer.searchByLabel(term, onResult),
       onSelect: (result) => {
         typeNameElement.value = result.id
         typeLabelElement.innerText = result.label

--- a/src/lib/component/TypeDefinitionDialog/index.js
+++ b/src/lib/component/TypeDefinitionDialog/index.js
@@ -22,7 +22,7 @@ export default class TypeDefinitionDialog extends PromiseDialog {
 
     const [idElement, labelElement] = super.el.querySelectorAll('input')
     const onSearch = (term, onResult) =>
-      definitionContainer.searchByLabel(term, onResult, autocompletionWs)
+      definitionContainer.searchByLabel(term, onResult)
 
     const onSelect = (result) => {
       idElement.value = result.id


### PR DESCRIPTION
## 概要
DefinitionContainer#searchByLabelメソッドが引数で受け取っているautocompletionWsを、TypeDictionaryから取得するように変更しました。

- DefinitionContainerクラスを初期化時autocompletionWsを受け取るようにしました
- DefinitionContainer#searchByLabelでは引数を受け取らず、クラス初期化時に受け取ったautocompletionWsを使用するようにしました

このPRではEditPropertiesDialogとTypeDefinitionDialogで使用しなくなったautocomplecationWsをそのままにしています。これを辿って削除していくと変更ファイル数が大きくなるので、別PRで対応予定です

## 動作確認

それぞれのダイアログでオートコンプリート機能が動作していることを確認

<img width="1013" alt="スクリーンショット 2025-05-14 16 01 16" src="https://github.com/user-attachments/assets/c03b53a2-1795-4b8e-b898-09183bccddb0" />


<img width="972" alt="スクリーンショット 2025-05-14 16 01 03" src="https://github.com/user-attachments/assets/eb58639d-c2ca-48e7-96aa-557461aa1243" />
