### PR TITLE
Remove autocompletionWs parameter from EditPropertiesDialog

### DIFF
--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/BlockEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/BlockEditMode/index.js
@@ -77,8 +77,7 @@ export default class BlockEditMode extends EditMode {
       mousePoint,
       annotationModel.typeDictionary.block,
       annotationModel,
-      'Entity',
-      getAutocompletionWs
+      'Entity'
     )
     this.#selectionModel = selectionModel
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/EditMode/PropertyEditor.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/EditMode/PropertyEditor.js
@@ -9,7 +9,6 @@ export default class PropertyEditor {
   #definitionContainer
   #annotationModel
   #annotationType
-  #getAutocompletionWs
 
   constructor(
     editorHTMLElement,
@@ -19,8 +18,7 @@ export default class PropertyEditor {
     mousePoint,
     definitionContainer,
     annotationModel,
-    annotationType,
-    getAutocompletionWs
+    annotationType
   ) {
     this.#editorHTMLElement = editorHTMLElement
     this.#commander = commander
@@ -30,7 +28,6 @@ export default class PropertyEditor {
     this.#definitionContainer = definitionContainer
     this.#annotationModel = annotationModel
     this.#annotationType = annotationType
-    this.#getAutocompletionWs = getAutocompletionWs
   }
 
   startEditing(selectionModel) {
@@ -61,7 +58,6 @@ export default class PropertyEditor {
       this.#palletName,
       this.#definitionContainer,
       this.#annotationModel.typeDictionary.attribute,
-      this.#getAutocompletionWs(),
       selectedItems,
       this.#pallet,
       this.#mousePoint

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/RelationEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/RelationEditMode/index.js
@@ -60,8 +60,7 @@ export default class RelationEditMode extends EditMode {
       mousePoint,
       annotationModel.typeDictionary.relation,
       annotationModel,
-      'Relation',
-      getAutocompletionWs
+      'Relation'
     )
     this.#selectionModel = selectionModel
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/TermEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/TermEditMode/index.js
@@ -77,8 +77,7 @@ export default class TermEditMode extends EditMode {
       mousePoint,
       annotationModel.typeDictionary.denotation,
       annotationModel,
-      'Denotation',
-      getAutocompletionWs
+      'Denotation'
     )
     this.#selectionModel = selectionModel
 

--- a/src/lib/component/EditPropertiesDialog/index.js
+++ b/src/lib/component/EditPropertiesDialog/index.js
@@ -9,7 +9,6 @@ import EditAttributeButtonHandler from './EditAttributeButtonHandler'
 export default class EditPropertiesDialog extends PromiseDialog {
   #attributeContainer
   #definitionContainer
-  #autocompletionWs
   #typeName
   #typeLabel
   #attributes
@@ -20,7 +19,6 @@ export default class EditPropertiesDialog extends PromiseDialog {
     palletName,
     definitionContainer,
     attributeContainer,
-    autocompletionWs,
     selectedItems,
     typeValuesPallet,
     mousePoint
@@ -48,7 +46,6 @@ export default class EditPropertiesDialog extends PromiseDialog {
 
     this.#attributeContainer = attributeContainer
     this.#definitionContainer = definitionContainer
-    this.#autocompletionWs = autocompletionWs
     const updateDisplay = (typeName, label, attributes) => {
       this.#typeName = typeName
       this.#typeLabel = label
@@ -120,12 +117,12 @@ export default class EditPropertiesDialog extends PromiseDialog {
     )
 
     // Setup autocomplete
-    this.#setupAutocomplete(autocompletionWs, definitionContainer)
+    this.#setupAutocomplete(definitionContainer)
   }
 
   #updateDisplay() {
     super.el.closest('.ui-dialog-content').innerHTML = this.#contentHTML
-    this.#setupAutocomplete(this.#autocompletionWs, this.#definitionContainer)
+    this.#setupAutocomplete(this.#definitionContainer)
   }
 
   get #contentHTML() {
@@ -137,7 +134,7 @@ export default class EditPropertiesDialog extends PromiseDialog {
     )
   }
 
-  #setupAutocomplete(autocompletionWs, definitionContainer) {
+  #setupAutocomplete(definitionContainer) {
     const typeNameElement = super.el.querySelector(
       '.textae-editor__edit-type-values-dialog__type-name'
     )


### PR DESCRIPTION
## 概要
EditPropertiesDialogで受け取っていたautocomplecationWsが不要になったので、autocomplecationWsの受け渡しをしている部分を遡って記述を削除しました。
TypeDefinitionDialogで受け取っていたautocomplecationWsの対応は別PRで行う予定です。

## 動作確認
ローカルのEditPropertiesDialogでオートコンプリート機能が使用できることを確認

<img width="963" alt="スクリーンショット 2025-05-14 16 40 53" src="https://github.com/user-attachments/assets/6f388c4b-3c43-4d6b-8eeb-f31c008555c3" />
