### PR TITLE
Typedefinitiondialog no autocompletionws

### DIFF
--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/BlockEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/BlockEditMode/index.js
@@ -31,9 +31,6 @@ export default class BlockEditMode extends EditMode {
   ) {
     super()
 
-    const getAutocompletionWs = () =>
-      annotationModel.typeDictionary.autocompletionWs
-
     this.#pallet = PalletFactory.create(
       editorHTMLElement,
       eventEmitter,
@@ -45,7 +42,6 @@ export default class BlockEditMode extends EditMode {
       'Block configuration',
       menuState,
       mousePoint,
-      getAutocompletionWs,
       'entity',
       selectionModel,
       annotationModel,

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/PalletFactory/bindPalletEvents/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/PalletFactory/bindPalletEvents/index.js
@@ -6,14 +6,13 @@ import checkButtonEnable from './checkButtonEnable'
 export default function (
   pallet,
   commander,
-  getAutocompletionWs,
   definitionContainer,
   annotationType,
   selectionModel,
   annotationModel
 ) {
   delegate(pallet.el, `.textae-editor__pallet__add-button`, 'click', () => {
-    new CreateTypeDefinitionDialog(definitionContainer, getAutocompletionWs())
+    new CreateTypeDefinitionDialog(definitionContainer)
       .open()
       .then(({ newType }) =>
         commander.invoke(
@@ -52,8 +51,7 @@ export default function (
       definitionContainer,
       e.target.dataset.id,
       e.target.dataset.color.toLowerCase(),
-      e.target.dataset.isDefault === 'true',
-      getAutocompletionWs()
+      e.target.dataset.isDefault === 'true'
     )
       .open()
       .then(({ id, changedProperties }) => {

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/PalletFactory/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/PalletFactory/index.js
@@ -14,7 +14,6 @@ export default class PalletWrapper {
     title,
     menuState,
     mousePoint,
-    getAutocompletionWs,
     annotationType,
     selectionModel,
     annotationModel,
@@ -36,7 +35,6 @@ export default class PalletWrapper {
     bindPalletEvents(
       pallet,
       commander,
-      getAutocompletionWs,
       definitionContainer,
       annotationType,
       selectionModel,

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/RelationEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/RelationEditMode/index.js
@@ -23,9 +23,6 @@ export default class RelationEditMode extends EditMode {
   ) {
     super()
 
-    const getAutocompletionWs = () =>
-      annotationModel.typeDictionary.autocompletionWs
-
     this.#pallet = PalletFactory.create(
       editorHTMLElement,
       eventEmitter,
@@ -37,7 +34,6 @@ export default class RelationEditMode extends EditMode {
       'Relation configuration',
       menuState,
       mousePoint,
-      getAutocompletionWs,
       'relation',
       selectionModel,
       annotationModel,

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/TermEditMode/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/TermEditMode/index.js
@@ -31,9 +31,6 @@ export default class TermEditMode extends EditMode {
   ) {
     super()
 
-    const getAutocompletionWs = () =>
-      annotationModel.typeDictionary.autocompletionWs
-
     this.#pallet = PalletFactory.create(
       editorHTMLElement,
       eventEmitter,
@@ -45,7 +42,6 @@ export default class TermEditMode extends EditMode {
       'Term configuration',
       menuState,
       mousePoint,
-      getAutocompletionWs,
       'entity',
       selectionModel,
       annotationModel,

--- a/src/lib/component/CreateTypeDefinitionDialog.js
+++ b/src/lib/component/CreateTypeDefinitionDialog.js
@@ -1,7 +1,7 @@
 import TypeDefinitionDialog from './TypeDefinitionDialog'
 
 export default class CreateTypeDefinitionDialog extends TypeDefinitionDialog {
-  constructor(definitionContainer, autocompletionWs) {
+  constructor(definitionContainer) {
     const convertToResultsFunc = (newId, newLabel, newColor, newDefault) => {
       if (newId === '') {
         return
@@ -32,7 +32,6 @@ export default class CreateTypeDefinitionDialog extends TypeDefinitionDialog {
         isDefault: false
       },
       definitionContainer,
-      autocompletionWs,
       convertToResultsFunc
     )
   }

--- a/src/lib/component/EditTypeDefinitionDialog/index.js
+++ b/src/lib/component/EditTypeDefinitionDialog/index.js
@@ -2,7 +2,7 @@ import TypeDefinitionDialog from '../TypeDefinitionDialog'
 import getDifference from './getDifference'
 
 export default class EditTypeDefinitionDialog extends TypeDefinitionDialog {
-  constructor(definitionContainer, id, color, isDefault, autocompletionWs) {
+  constructor(definitionContainer, id, color, isDefault) {
     const label = definitionContainer.getLabel(id) || ''
 
     const beforeChange = {
@@ -28,12 +28,6 @@ export default class EditTypeDefinitionDialog extends TypeDefinitionDialog {
       }
     }
 
-    super(
-      'Edit type',
-      beforeChange,
-      definitionContainer,
-      autocompletionWs,
-      convertToReseltsFunc
-    )
+    super('Edit type', beforeChange, definitionContainer, convertToReseltsFunc)
   }
 }

--- a/src/lib/component/TypeDefinitionDialog/index.js
+++ b/src/lib/component/TypeDefinitionDialog/index.js
@@ -3,13 +3,7 @@ import Autocomplete from 'popover-autocomplete'
 import template from './template'
 
 export default class TypeDefinitionDialog extends PromiseDialog {
-  constructor(
-    title,
-    content,
-    definitionContainer,
-    autocompletionWs,
-    convertToResultsFunc
-  ) {
+  constructor(title, content, definitionContainer, convertToResultsFunc) {
     super(title, template(content), {}, () => {
       const inputs = super.el.querySelectorAll('input')
       return convertToResultsFunc(


### PR DESCRIPTION
## 概要

TypeDefinitionDialogで受け取っていたautocomplecationWsが不要になったので、autocomplecationWsの受け渡しをしている部分を遡って記述を削除しました。

## 動作確認

TypeDefinitionDialogでオートコンプリートを使用できることを確認しました。

<img width="913" alt="スクリーンショット 2025-05-14 17 02 23" src="https://github.com/user-attachments/assets/98ee4f6f-e10f-4dcb-8f8c-156673861d96" />
