### PR TITLE
Extension autocomplete api

### DIFF
--- a/dev/development.html
+++ b/dev/development.html
@@ -310,6 +310,29 @@
 
             // Focus on the annotation specified by the ID.
             editor.focusDenotation('T1')
+
+            // Set a callback function for autocomplete suggestions.
+            // This function receives the input string `term` and returns a JSON string
+            // of candidate objects whose label includes the given term.
+            // The returned JSON is used by the TextAE editor's autocomplete feature.
+            editor.autocompletionCallback = (term) => {
+                const dictionary = [
+                    {
+                        id: 'http://dbpedia.org/ontology/super_long_long_name_items/parent0',
+                        label: 'parent0'
+                    },
+                    {
+                        id: 'http://dbpedia.org/ontology/parent1',
+                        label: 'parent1'
+                    },
+                    {
+                        id: 'http://dbpedia.org/ontology/parent2',
+                        label: 'parent2'
+                    }
+                ]
+
+                return dictionary.filter((d) => d.label.includes(term))
+            }
         }
     </script>
 

--- a/dev/development.html
+++ b/dev/development.html
@@ -312,9 +312,9 @@
             editor.focusDenotation('T1')
 
             // Set a callback function for autocomplete suggestions.
-            // This function receives the input string `term` and returns a JSON string
+            // This function receives the input string `term` and returns an array
             // of candidate objects whose label includes the given term.
-            // The returned JSON is used by the TextAE editor's autocomplete feature.
+            // The returned array is used by the TextAE editor's autocomplete feature.
             editor.autocompletionCallback = (term) => {
                 const dictionary = [
                     {

--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -161,13 +161,20 @@ export default class DefinitionContainer {
   }
 
   searchByLabel(term, done) {
-    searchTerm(
-      term,
-      done,
-      this.#autocompletionWs,
-      this.findByLabel(term),
-      this.#autocompletionFunction
-    )
+    if (typeof this.#autocompletionFunction() === 'function') {
+      const result = this.#autocompletionFunction()(term)
+      const filteredData = (result || []).filter(
+        (newDatum) =>
+          !this.findByLabel(term).some(
+            (localDatum) => newDatum.id === localDatum.id
+          )
+      )
+
+      done(this.findByLabel(term).concat(filteredData))
+      return
+    }
+
+    searchTerm(term, done, this.#autocompletionWs, this.findByLabel(term))
   }
 
   findByLabel(term) {

--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -15,12 +15,20 @@ export default class DefinitionContainer {
   #defaultColor
   #defaultType
   #autocompletionWs = ''
+  #autocompletionFunction
 
-  constructor(eventEmitter, annotationType, getAllInstanceFunc, defaultColor) {
+  constructor(
+    eventEmitter,
+    annotationType,
+    getAllInstanceFunc,
+    defaultColor,
+    autocompletionFunction
+  ) {
     this.#eventEmitter = eventEmitter
     this.#annotationType = annotationType
     this.#getAllInstanceFunc = getAllInstanceFunc
     this.#defaultColor = defaultColor
+    this.#autocompletionFunction = autocompletionFunction
   }
 
   set autocompletionWs(value) {
@@ -153,7 +161,13 @@ export default class DefinitionContainer {
   }
 
   searchByLabel(term, done) {
-    searchTerm(term, done, this.#autocompletionWs, this.findByLabel(term))
+    searchTerm(
+      term,
+      done,
+      this.#autocompletionWs,
+      this.findByLabel(term),
+      this.#autocompletionFunction
+    )
   }
 
   findByLabel(term) {

--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -17,22 +17,19 @@ export default class DefinitionContainer {
   #autocompletionWs = ''
   #autocompletionFunction
 
-  constructor(
-    eventEmitter,
-    annotationType,
-    getAllInstanceFunc,
-    defaultColor,
-    autocompletionFunction
-  ) {
+  constructor(eventEmitter, annotationType, getAllInstanceFunc, defaultColor) {
     this.#eventEmitter = eventEmitter
     this.#annotationType = annotationType
     this.#getAllInstanceFunc = getAllInstanceFunc
     this.#defaultColor = defaultColor
-    this.#autocompletionFunction = autocompletionFunction
   }
 
   set autocompletionWs(value) {
     this.#autocompletionWs = value
+  }
+
+  set autocompletionFunction(fn) {
+    this.#autocompletionFunction = fn
   }
 
   get autocompletionWs() {
@@ -161,8 +158,8 @@ export default class DefinitionContainer {
   }
 
   searchByLabel(term, done) {
-    if (typeof this.#autocompletionFunction() === 'function') {
-      const result = this.#autocompletionFunction()(term)
+    if (typeof this.#autocompletionFunction === 'function') {
+      const result = this.#autocompletionFunction(term)
       const filteredData = (result || []).filter(
         (newDatum) =>
           !this.findByLabel(term).some(

--- a/src/lib/Editor/AnnotationModel/TypeDictionary.js
+++ b/src/lib/Editor/AnnotationModel/TypeDictionary.js
@@ -38,6 +38,12 @@ export default class TypeDictionary {
     this.#blockContainer.autocompletionWs = value
   }
 
+  set autocompletionFunction(fn) {
+    this.#denotationContainer.autocompletionFunction = fn
+    this.#relationContainer.autocompletionFunction = fn
+    this.#blockContainer.autocompletionFunction = fn
+  }
+
   get denotation() {
     return this.#denotationContainer
   }

--- a/src/lib/Editor/AnnotationModel/index.js
+++ b/src/lib/Editor/AnnotationModel/index.js
@@ -38,8 +38,7 @@ export default class AnnotationModel {
     startJQueryUIDialogWait,
     endJQueryUIDialogWait,
     isConfigLocked,
-    additionalPaddingTop,
-    autocompletionFunction
+    additionalPaddingTop
   ) {
     this.#sourceDoc = ''
     this.#namespaceInstanceContainer = new InstanceContainer(
@@ -50,8 +49,7 @@ export default class AnnotationModel {
       eventEmitter,
       'relation',
       () => this.#relationInstanceContainer.all,
-      '#00CC66',
-      autocompletionFunction
+      '#00CC66'
     )
 
     this.#relationInstanceContainer = new RelationInstanceContainer(
@@ -113,15 +111,13 @@ export default class AnnotationModel {
       eventEmitter,
       'entity',
       () => this.#entityInstanceContainer.denotations,
-      '#77DDDD',
-      autocompletionFunction
+      '#77DDDD'
     )
     const blockDefinitionContainer = new DefinitionContainer(
       eventEmitter,
       'entity',
       () => this.#entityInstanceContainer.blocks,
-      '#77DDDD',
-      autocompletionFunction
+      '#77DDDD'
     )
     this.#typeDictionary = new TypeDictionary(
       eventEmitter,
@@ -218,6 +214,10 @@ export default class AnnotationModel {
     // This seems to happen especially when the browser is wide with only one editor.
     // The true cause is unknown, but it can be avoided by doing the layout twice.
     this.reLayout()
+  }
+
+  set autocompletionFunction(fn) {
+    this.#typeDictionary.autocompletionFunction = fn
   }
 
   get externalFormat() {

--- a/src/lib/Editor/AnnotationModel/index.js
+++ b/src/lib/Editor/AnnotationModel/index.js
@@ -38,7 +38,8 @@ export default class AnnotationModel {
     startJQueryUIDialogWait,
     endJQueryUIDialogWait,
     isConfigLocked,
-    additionalPaddingTop
+    additionalPaddingTop,
+    autocompletionFunction
   ) {
     this.#sourceDoc = ''
     this.#namespaceInstanceContainer = new InstanceContainer(
@@ -49,7 +50,8 @@ export default class AnnotationModel {
       eventEmitter,
       'relation',
       () => this.#relationInstanceContainer.all,
-      '#00CC66'
+      '#00CC66',
+      autocompletionFunction
     )
 
     this.#relationInstanceContainer = new RelationInstanceContainer(
@@ -111,13 +113,15 @@ export default class AnnotationModel {
       eventEmitter,
       'entity',
       () => this.#entityInstanceContainer.denotations,
-      '#77DDDD'
+      '#77DDDD',
+      autocompletionFunction
     )
     const blockDefinitionContainer = new DefinitionContainer(
       eventEmitter,
       'entity',
       () => this.#entityInstanceContainer.blocks,
-      '#77DDDD'
+      '#77DDDD',
+      autocompletionFunction
     )
     this.#typeDictionary = new TypeDictionary(
       eventEmitter,

--- a/src/lib/Editor/index.js
+++ b/src/lib/Editor/index.js
@@ -23,6 +23,7 @@ export default class Editor {
   #lastSelectedDenotationIDCallback
   #scrollEventListeners
   #useCase
+  #autocompletionFunction
 
   constructor(
     element,
@@ -56,7 +57,8 @@ export default class Editor {
       startJQueryUIDialogWait,
       endJQueryUIDialogWait,
       startUpOptions.configLock === 'true',
-      startUpOptions.additionalPaddingTop
+      startUpOptions.additionalPaddingTop,
+      () => this.getAutocompletionFunction()
     )
 
     this.#element = element
@@ -145,6 +147,17 @@ export default class Editor {
         callback
       )
     }
+  }
+
+  setAutocompletionFunction(callback) {
+    this.#autocompletionFunction = callback
+  }
+
+  getAutocompletionFunction() {
+    if (typeof this.#autocompletionFunction === 'function') {
+      return this.#autocompletionFunction
+    }
+    return null
   }
 
   get HTMLElementID() {

--- a/src/lib/Editor/index.js
+++ b/src/lib/Editor/index.js
@@ -23,7 +23,6 @@ export default class Editor {
   #lastSelectedDenotationIDCallback
   #scrollEventListeners
   #useCase
-  #autocompletionFunction = null
 
   constructor(
     element,
@@ -57,8 +56,7 @@ export default class Editor {
       startJQueryUIDialogWait,
       endJQueryUIDialogWait,
       startUpOptions.configLock === 'true',
-      startUpOptions.additionalPaddingTop,
-      () => this.getAutocompletionFunction()
+      startUpOptions.additionalPaddingTop
     )
 
     this.#element = element
@@ -153,11 +151,7 @@ export default class Editor {
     if (typeof callback !== 'function') {
       throw new TypeError('autocompletionFunction must be a function')
     }
-    this.#autocompletionFunction = callback
-  }
-
-  getAutocompletionFunction() {
-    return this.#autocompletionFunction
+    this.#annotationModel.autocompletionFunction = callback
   }
 
   get HTMLElementID() {

--- a/src/lib/Editor/index.js
+++ b/src/lib/Editor/index.js
@@ -23,7 +23,7 @@ export default class Editor {
   #lastSelectedDenotationIDCallback
   #scrollEventListeners
   #useCase
-  #autocompletionFunction
+  #autocompletionFunction = null
 
   constructor(
     element,
@@ -150,14 +150,14 @@ export default class Editor {
   }
 
   setAutocompletionFunction(callback) {
+    if (typeof callback !== 'function') {
+      throw new TypeError('autocompletionFunction must be a function')
+    }
     this.#autocompletionFunction = callback
   }
 
   getAutocompletionFunction() {
-    if (typeof this.#autocompletionFunction === 'function') {
-      return this.#autocompletionFunction
-    }
-    return null
+    return this.#autocompletionFunction
   }
 
   get HTMLElementID() {

--- a/src/lib/component/searchTerm.js
+++ b/src/lib/component/searchTerm.js
@@ -2,8 +2,33 @@ export default function searchTerm(
   term,
   done,
   autocompletionWs,
-  localData = []
+  localData = [],
+  autocompletionFunction = null
 ) {
+  if (
+    autocompletionFunction &&
+    typeof autocompletionFunction() === 'function'
+  ) {
+    const result = autocompletionFunction()(term)
+
+    if (result && typeof result.then === 'function') {
+      result.then((data) => {
+        const filteredData = data.filter(
+          (newDatum) =>
+            !localData.some((localDatum) => newDatum.id === localDatum.id)
+        )
+        done(localData.concat(filteredData))
+      })
+    } else {
+      const filteredData = (result || []).filter(
+        (newDatum) =>
+          !localData.some((localDatum) => newDatum.id === localDatum.id)
+      )
+      done(localData.concat(filteredData))
+    }
+    return
+  }
+
   if (!autocompletionWs) {
     done(localData)
     return

--- a/src/lib/component/searchTerm.js
+++ b/src/lib/component/searchTerm.js
@@ -2,33 +2,8 @@ export default function searchTerm(
   term,
   done,
   autocompletionWs,
-  localData = [],
-  autocompletionFunction = null
+  localData = []
 ) {
-  if (
-    autocompletionFunction &&
-    typeof autocompletionFunction() === 'function'
-  ) {
-    const result = autocompletionFunction()(term)
-
-    if (result && typeof result.then === 'function') {
-      result.then((data) => {
-        const filteredData = data.filter(
-          (newDatum) =>
-            !localData.some((localDatum) => newDatum.id === localDatum.id)
-        )
-        done(localData.concat(filteredData))
-      })
-    } else {
-      const filteredData = (result || []).filter(
-        (newDatum) =>
-          !localData.some((localDatum) => newDatum.id === localDatum.id)
-      )
-      done(localData.concat(filteredData))
-    }
-    return
-  }
-
   if (!autocompletionWs) {
     done(localData)
     return

--- a/src/lib/textae/API.js
+++ b/src/lib/textae/API.js
@@ -19,6 +19,10 @@ export default class API {
     this._editor.setLastSelectedDenotationIDCallback(callback)
   }
 
+  set autocompletionCallback(callback) {
+    this._editor.setAutocompletionFunction(callback)
+  }
+
   get id() {
     return this._editor.HTMLElementID
   }


### PR DESCRIPTION
## 概要

Autocomplete APIの拡張を行いました。
htmlファイルのscriptタグ内で定義した関数を利用して、オートコンプリート機能で出力する候補を設定できるようにしました。

```html
    </script>
        function initializeTextAE() {

            const editor = window.initializeTextAEEditor()
                .find((editor) => editor.id === 'my_text-ae_editor')

            editor.autocompletionCallback = (term) => {
                const dictionary = [
                    {
                        id: 'http://dbpedia.org/ontology/super_long_long_name_items/parent0',
                        label: 'parent0'
                    },
                    {
                        id: 'http://dbpedia.org/ontology/parent1',
                        label: 'parent1'
                    },
                    {
                        id: 'http://dbpedia.org/ontology/parent2',
                        label: 'parent2'
                    }
                ]

                return dictionary.filter((d) => d.label.includes(term))
            }
        }
    </script>
```

## 動作確認
それぞれのダイアログでオートコンプリート機能が使用できることを確認しました。

### EditPropertiesDialog

https://github.com/user-attachments/assets/22206b7d-544b-4ae9-9454-035a189e62c4

### TypeDefinitionDialog

https://github.com/user-attachments/assets/b7906451-dd0f-4de5-9630-0dc3a538e139

既存のダイアログが動作することを確認しました。

<img width="1352" alt="スクリーンショット 2025-05-15 14 31 03" src="https://github.com/user-attachments/assets/e645e2a2-f3f5-4f1c-a8eb-88fee57ceff3" />
<img width="1399" alt="スクリーンショット 2025-05-15 14 31 18" src="https://github.com/user-attachments/assets/775e9c01-7cf0-4411-8393-bc8b72fb79bb" />
