### PR TITLE
Rename searchTerm to fetchAutocompleteFromWs

### DIFF
--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -4,7 +4,7 @@ import sortByCountAndName from './sortByCountAndName'
 import countUsage from './countUsage'
 import DefinedType from '../DefinedType'
 import DefinedTypeContainer from './DefinedTypeContainer'
-import searchTerm from '../../../component/searchTerm'
+import fetchAutocompleteFromWs from '../../../component/fetchAutocompleteFromWs'
 
 export default class DefinitionContainer {
   #eventEmitter
@@ -171,7 +171,12 @@ export default class DefinitionContainer {
       return
     }
 
-    searchTerm(term, done, this.#autocompletionWs, this.findByLabel(term))
+    fetchAutocompleteFromWs(
+      term,
+      done,
+      this.#autocompletionWs,
+      this.findByLabel(term)
+    )
   }
 
   findByLabel(term) {

--- a/src/lib/component/EditStringAttributeDialog.js
+++ b/src/lib/component/EditStringAttributeDialog.js
@@ -2,7 +2,7 @@ import delegate from 'delegate'
 import PromiseDialog from './PromiseDialog'
 import anemone from './anemone'
 import Autocomplete from 'popover-autocomplete'
-import searchTerm from './searchTerm'
+import fetchAutocompleteFromWs from './fetchAutocompleteFromWs'
 
 function template(context) {
   const { subjects, pred, value, label } = context
@@ -123,7 +123,7 @@ export default class EditStringAttributeDialog extends PromiseDialog {
     new Autocomplete({
       inputElement,
       onSearch: (term, onResult) =>
-        searchTerm(term, onResult, attrDef.autocompletionWs),
+        fetchAutocompleteFromWs(term, onResult, attrDef.autocompletionWs),
       onSelect: (result) => {
         inputElement.value = result.id
         labelElement.value = result.label

--- a/src/lib/component/fetchAutocompleteFromWs.js
+++ b/src/lib/component/fetchAutocompleteFromWs.js
@@ -1,4 +1,4 @@
-export default function searchTerm(
+export default function fetchAutocompleteFromWs(
   term,
   done,
   autocompletionWs,


### PR DESCRIPTION
## 概要

`searchTerm`メソッドの名称を、`autocompletionWs`を使用していることがわかるように`fetchAutocompleteFromWs`という名称に変更しました。

## 動作確認

autocompletionWsを使用しているエディタで問題なくオートコンプリート機能が使用できることを確認しました。

<img width="1262" alt="スクリーンショット 2025-05-16 11 13 25" src="https://github.com/user-attachments/assets/c6648121-8c2a-4669-b003-5d50ab83c9ea" />

<img width="1170" alt="スクリーンショット 2025-05-16 11 14 40" src="https://github.com/user-attachments/assets/22fc1fbd-da27-4a4b-b80d-77a44c6ffe75" />
