### PR TITLE
Add mergeWithLocalData method to DefinitionContainer for merging local and external data

### DIFF
--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -160,14 +160,8 @@ export default class DefinitionContainer {
   searchByLabel(term, done) {
     if (typeof this.#autocompletionFunction === 'function') {
       const result = this.#autocompletionFunction(term)
-      const filteredData = (result || []).filter(
-        (newDatum) =>
-          !this.findByLabel(term).some(
-            (localDatum) => newDatum.id === localDatum.id
-          )
-      )
-
-      done(this.findByLabel(term).concat(filteredData))
+      const merged = this.mergeWithLocalData(result, term)
+      done(merged)
       return
     }
 
@@ -181,6 +175,15 @@ export default class DefinitionContainer {
 
   findByLabel(term) {
     return this.#definedTypes.labelsIncludes(term)
+  }
+
+  mergeWithLocalData(externalData, term) {
+    const localData = this.findByLabel(term)
+    const filteredData = (externalData || []).filter(
+      (newDatum) =>
+        !localData.some((localDatum) => newDatum.id === localDatum.id)
+    )
+    return localData.concat(filteredData)
   }
 
   get pallet() {


### PR DESCRIPTION
## 概要

`autocomplecationFunctiton`で取得した配列と、localDataとマージする処理をメソッドに切り出しました。

## 動作確認

autocompletionFunctionを使用しているエディタで問題なくオートコンプリート機能が使用できることを確認しました。

<img width="1119" alt="スクリーンショット 2025-05-16 11 56 58" src="https://github.com/user-attachments/assets/deb03134-8c0a-4484-b775-704f73e5a2d9" />
<img width="912" alt="スクリーンショット 2025-05-16 11 57 13" src="https://github.com/user-attachments/assets/5ed4f1aa-8b4a-4143-a04d-d8a2a3350b6b" />
