### PR TITLE
Inline fetchAutocompleteFromWs logic into DefinitionContainer and remove its usage

### DIFF
--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -157,31 +157,30 @@ export default class DefinitionContainer {
   }
 
   searchByLabel(term, done) {
-    if (typeof this.#autocompletionFunction === 'function') {
+    if (
+      !this.#autocompletionWs &&
+      typeof this.#autocompletionFunction !== 'function'
+    ) {
+      done(this.findByLabel(term))
+    } else if (typeof this.#autocompletionFunction === 'function') {
       const result = this.#autocompletionFunction(term)
       const merged = this.mergeWithLocalData(result, term)
       done(merged)
-      return
+    } else {
+      const url = new URL(this.#autocompletionWs, location)
+      url.searchParams.append('term', term)
+
+      fetch(url.href)
+        .then((response) => {
+          if (response.ok) {
+            return response.json()
+          }
+        })
+        .then((data) => {
+          const merged = this.mergeWithLocalData(data, term)
+          done(merged)
+        })
     }
-
-    if (!this.#autocompletionWs) {
-      done(this.findByLabel(term))
-      return
-    }
-
-    const url = new URL(this.#autocompletionWs, location)
-    url.searchParams.append('term', term)
-
-    fetch(url.href)
-      .then((response) => {
-        if (response.ok) {
-          return response.json()
-        }
-      })
-      .then((data) => {
-        const merged = this.mergeWithLocalData(data, term)
-        done(merged)
-      })
   }
 
   findByLabel(term) {

--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -162,25 +162,29 @@ export default class DefinitionContainer {
       typeof this.#autocompletionFunction !== 'function'
     ) {
       done(this.findByLabel(term))
-    } else if (typeof this.#autocompletionFunction === 'function') {
+      return
+    }
+
+    if (typeof this.#autocompletionFunction === 'function') {
       const result = this.#autocompletionFunction(term)
       const merged = this.mergeWithLocalData(result, term)
       done(merged)
-    } else {
-      const url = new URL(this.#autocompletionWs, location)
-      url.searchParams.append('term', term)
-
-      fetch(url.href)
-        .then((response) => {
-          if (response.ok) {
-            return response.json()
-          }
-        })
-        .then((data) => {
-          const merged = this.mergeWithLocalData(data, term)
-          done(merged)
-        })
+      return
     }
+
+    const url = new URL(this.#autocompletionWs, location)
+    url.searchParams.append('term', term)
+
+    fetch(url.href)
+      .then((response) => {
+        if (response.ok) {
+          return response.json()
+        }
+      })
+      .then((data) => {
+        const merged = this.mergeWithLocalData(data, term)
+        done(merged)
+      })
   }
 
   findByLabel(term) {

--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -4,7 +4,6 @@ import sortByCountAndName from './sortByCountAndName'
 import countUsage from './countUsage'
 import DefinedType from '../DefinedType'
 import DefinedTypeContainer from './DefinedTypeContainer'
-import fetchAutocompleteFromWs from '../../../component/fetchAutocompleteFromWs'
 
 export default class DefinitionContainer {
   #eventEmitter
@@ -165,12 +164,24 @@ export default class DefinitionContainer {
       return
     }
 
-    fetchAutocompleteFromWs(
-      term,
-      done,
-      this.#autocompletionWs,
-      this.findByLabel(term)
-    )
+    if (!this.#autocompletionWs) {
+      done(this.findByLabel(term))
+      return
+    }
+
+    const url = new URL(this.#autocompletionWs, location)
+    url.searchParams.append('term', term)
+
+    fetch(url.href)
+      .then((response) => {
+        if (response.ok) {
+          return response.json()
+        }
+      })
+      .then((data) => {
+        const merged = this.mergeWithLocalData(data, term)
+        done(merged)
+      })
   }
 
   findByLabel(term) {

--- a/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
+++ b/src/lib/Editor/AnnotationModel/DefinitionContainer/index.js
@@ -157,14 +157,6 @@ export default class DefinitionContainer {
   }
 
   searchByLabel(term, done) {
-    if (
-      !this.#autocompletionWs &&
-      typeof this.#autocompletionFunction !== 'function'
-    ) {
-      done(this.findByLabel(term))
-      return
-    }
-
     if (typeof this.#autocompletionFunction === 'function') {
       const result = this.#autocompletionFunction(term)
       const merged = this.mergeWithLocalData(result, term)
@@ -172,19 +164,24 @@ export default class DefinitionContainer {
       return
     }
 
-    const url = new URL(this.#autocompletionWs, location)
-    url.searchParams.append('term', term)
+    if (this.#autocompletionWs) {
+      const url = new URL(this.#autocompletionWs, location)
+      url.searchParams.append('term', term)
 
-    fetch(url.href)
-      .then((response) => {
-        if (response.ok) {
-          return response.json()
-        }
-      })
-      .then((data) => {
-        const merged = this.mergeWithLocalData(data, term)
-        done(merged)
-      })
+      fetch(url.href)
+        .then((response) => {
+          if (response.ok) {
+            return response.json()
+          }
+        })
+        .then((data) => {
+          const merged = this.mergeWithLocalData(data, term)
+          done(merged)
+        })
+      return
+    }
+
+    done(this.findByLabel(term))
   }
 
   findByLabel(term) {


### PR DESCRIPTION
## 概要

- fetchAutocompleteFromWsの処理をDefinitionContainerにインライン展開しました。
- DefinitionContainerがfetchAutocompleteFromWsを使うための記述を削除しました。

## 動作確認

fetchAutocompleteFromWsを使用していたエディタで、問題なくオートコンプリート機能が使用できることを確認しました。

<img width="1169" alt="スクリーンショット 2025-05-16 15 34 39" src="https://github.com/user-attachments/assets/56c4af6a-b113-4800-b822-2d35579da9d9" />
