### PR TITLE
fix: replace all imports/requires of simple-inline-text-annotation with @pubann/simple-inline-text-annotation

### DIFF
--- a/src/lib/Editor/RemoteResource/AnnotationLoader/parseResponse/index.js
+++ b/src/lib/Editor/RemoteResource/AnnotationLoader/parseResponse/index.js
@@ -1,5 +1,5 @@
 import { isJsonResponse, isTxtResponse } from './responseTypes'
-import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'
+import SimpleInlineTextAnnotation from '@pubann/simple-inline-text-annotation'
 
 export default async function parseResponse(response, url) {
   if (isJsonResponse(response, url)) {

--- a/src/lib/Editor/RemoteResource/AnnotationSaver/prepareRequestBody.js
+++ b/src/lib/Editor/RemoteResource/AnnotationSaver/prepareRequestBody.js
@@ -1,4 +1,4 @@
-import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'
+import SimpleInlineTextAnnotation from '@pubann/simple-inline-text-annotation'
 
 export default function prepareRequestBody(editedData, format) {
   if (format === 'json') {

--- a/src/lib/Editor/StartUpOptions/AnnotationResource.js
+++ b/src/lib/Editor/StartUpOptions/AnnotationResource.js
@@ -1,5 +1,5 @@
 import isJSON from '../../isJSON'
-import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'
+import SimpleInlineTextAnnotation from '@pubann/simple-inline-text-annotation'
 
 export default class AnnotationResource {
   #annotation

--- a/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile/parseFileContent.js
+++ b/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationFile/parseFileContent.js
@@ -1,4 +1,4 @@
-import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'
+import SimpleInlineTextAnnotation from '@pubann/simple-inline-text-annotation'
 
 export default function parseFileContent(fileContent) {
   try {

--- a/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationText.js
+++ b/src/lib/Editor/UseCase/PersistenceInterface/readAnnotationText.js
@@ -2,7 +2,7 @@ import isJSON from '../../../isJSON'
 import loadAnnotation from '../../loadAnnotation'
 import DataSource from '../../DataSource'
 import alertifyjs from 'alertifyjs'
-import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'
+import SimpleInlineTextAnnotation from '@pubann/simple-inline-text-annotation'
 
 export default function readAnnotationText(eventEmitter, text, format) {
   if (format === 'json') {

--- a/src/lib/component/SaveAnnotationDialog/bind/createDownloadPathForFormat.js
+++ b/src/lib/component/SaveAnnotationDialog/bind/createDownloadPathForFormat.js
@@ -1,5 +1,5 @@
 import createDownloadPath from '../../createDownloadPath'
-import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'
+import SimpleInlineTextAnnotation from '@pubann/simple-inline-text-annotation'
 
 export default function createDownloadPathForFormat(data, format) {
   if (format === 'json') {


### PR DESCRIPTION
## 概要

#204
`simple-inline-text-annotation`をスコープ付きにしたときの対応漏れ

`simple-inline-text-annotation`をimportしていたファイルが差し替えた後のパッケージ名に変更できていなかったので、対応しました。

## 動作確認
stable/4ブランチで`npm run watch`を実行時に正常な動作をしていないことを確認
<img width="1109" alt="スクリーンショット 2025-05-23 14 20 30" src="https://github.com/user-attachments/assets/52a97ab1-07de-47eb-8b61-74eda846b786" />

作業ブランチで`npm run watch`を実行時に正常に表示されていることを確認
<img width="1114" alt="スクリーンショット 2025-05-23 14 21 45" src="https://github.com/user-attachments/assets/e89a422c-2e44-4ffb-b54f-f46b5229461c" />
