### PR TITLE
Update .gitignore for new paths after package rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ npm-debug.log
 src/lib/fonts/
 src/lib/css/textae.css
 dev/bundle.js
-tmp/@pubann/textae-*.js
-tmp/@pubann/textae-*.min.js
-tmp/css/@pubann/textae*.css
+/tmp/*
+!/tmp/.keep
 textae-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@ npm-debug.log
 src/lib/fonts/
 src/lib/css/textae.css
 dev/bundle.js
-tmp/textae-*.js
-tmp/textae-*.min.js
-tmp/css/textae*.css
 tmp/@pubann/textae-*.js
 tmp/@pubann/textae-*.min.js
 tmp/css/@pubann/textae*.css

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ dev/bundle.js
 tmp/textae-*.js
 tmp/textae-*.min.js
 tmp/css/textae*.css
+tmp/@pubann/textae-*.js
+tmp/@pubann/textae-*.min.js
+tmp/css/@pubann/textae*.css
 textae-*.tgz


### PR DESCRIPTION
## 概要

- .gitignoreを修正しました

   - `npm run release`実行時にtmpディレクトリに生成されるファイルを指定しました
    - 以前のパスのファイルは作成されなくなったため削除しました

## 動作確認

- ローカルのtmpファイルの中身を削除
- `npm run release`を実行して、意図通りのパスのファイルが生成されていることを確認

<img width="398" alt="スクリーンショット 2025-05-23 15 49 38" src="https://github.com/user-attachments/assets/e237089f-3287-4c1a-a020-c5b9dc5a05a5" />

- `git status`で差分にtmpディレクトリの中のファイルが含まれていないことを確認