### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,7 @@
     "webpack-cli": "^6.0.1"
   },
   "files": [
-    "dist/lib/textae-{{version}}.js",
-    "dist/lib/textae-{{version}}.min.js",
-    "dist/lib/css/textae-{{version}}.css",
-    "dist/lib/css/textae-{{version}}.min.css",
+    "dist/lib",
     "scripts/postinstall.js"
   ],
   "homepage": "https://github.com/pubannotation/textae",


### PR DESCRIPTION
## 概要

- `package.json`の`files`の修正が抜けており、npmパッケージの中に意図したファイルが含まれていない問題の修正を行いました
   - このPRマージ後にpublish予定です

- `files`の指定でdist/lib配下のすべてのファイルを指定しました
- READMEの表示を修正しました
   - バージョンの指定について追記しました 

## 動作確認

- `npm pack`を実行
   - `pubann-textae-14.0.0.tgz`を作成
   - 参考: https://numb86-tech.hatenablog.com/entry/2019/06/28/220736 動作確認の章
- 動作確認用のディレクトリに`pubannt-extae-14.0.0.tgz`を移動して解凍
   - 解凍したディレクトリに`dist`と`script`以外のディレクトリが存在しないことを確認
<img width="745" alt="スクリーンショット 2025-06-10 17 23 23" src="https://github.com/user-attachments/assets/2ff0ad85-b704-4076-8d64-a155f27696e2" />


- 動作確認用のpackage.jsonに解凍した`pubannt-extae-14.0.0`を指定して`npm install`
<img width="628" alt="スクリーンショット 2025-06-10 13 19 24" src="https://github.com/user-attachments/assets/ba35a121-c11a-46de-9202-5337abc00ca2" />

- `index.html`を作成

<img width="773" alt="スクリーンショット 2025-06-10 17 21 24" src="https://github.com/user-attachments/assets/fc7e206e-4f4f-4e65-84fd-257569e48404" />



- 動作していることを確認
<img width="1027" alt="スクリーンショット 2025-06-10 13 19 01" src="https://github.com/user-attachments/assets/2f7331a7-640e-4f48-92a1-1f44ba94ffbd" />
