### PR TITLE
Add selected text parameter to external format

### DIFF
--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
@@ -1,11 +1,15 @@
 import EditMode from './EditMode'
 
 export default class ViewMode extends EditMode {
+  #editorHTMLElement
   #startOffset
   #endOffset
 
-  constructor(eventEmitter) {
+  constructor(editorHTMLElement, eventEmitter) {
     super()
+
+    this.#editorHTMLElement = editorHTMLElement
+
     document.addEventListener('selectionchange', () => {
       this.#updateSelectedTextOffsets()
 
@@ -25,22 +29,22 @@ export default class ViewMode extends EditMode {
     const selection = document.getSelection()
     if (selection && selection.rangeCount > 0) {
       const range = selection.getRangeAt(0)
-      const textBoxes = document.querySelectorAll('.textae-editor__text-box')
+      const textBox = this.#editorHTMLElement.querySelector(
+        '.textae-editor__text-box'
+      )
 
-      textBoxes.forEach((textBox) => {
-        if (textBox.contains(range.startContainer)) {
-          this.#startOffset = this.#getOffsetInContainer(
-            textBox,
-            range.startContainer,
-            range.startOffset
-          )
-          this.#endOffset = this.#getOffsetInContainer(
-            textBox,
-            range.endContainer,
-            range.endOffset
-          )
-        }
-      })
+      if (textBox.contains(range.startContainer)) {
+        this.#startOffset = this.#getOffsetInContainer(
+          textBox,
+          range.startContainer,
+          range.startOffset
+        )
+        this.#endOffset = this.#getOffsetInContainer(
+          textBox,
+          range.endContainer,
+          range.endOffset
+        )
+      }
     }
   }
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
@@ -39,7 +39,10 @@ export default class ViewMode extends EditMode {
         '.textae-editor__text-box'
       )
 
-      if (textBox.contains(range.startContainer)) {
+      if (
+        textBox.contains(range.startContainer) &&
+        textBox.contains(range.endContainer)
+      ) {
         this.#startOffset = this.#getOffsetInContainer(
           textBox,
           range.startContainer,

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
@@ -18,6 +18,12 @@ export default class ViewMode extends EditMode {
   }
 
   get selectedText() {
+    if (this.#startOffset === undefined || this.#endOffset === undefined) {
+      return {
+        status: 'unselected'
+      }
+    }
+
     return {
       begin: this.#startOffset,
       end: this.#endOffset,
@@ -45,6 +51,9 @@ export default class ViewMode extends EditMode {
           range.endOffset
         )
       }
+    } else {
+      this.#startOffset = undefined
+      this.#endOffset = undefined
     }
   }
 

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
@@ -1,12 +1,61 @@
 import EditMode from './EditMode'
 
 export default class ViewMode extends EditMode {
+  #startOffset
+  #endOffset
+
+  constructor(eventEmitter) {
+    super()
+    document.addEventListener('selectionchange', () => {
+      this.#updateSelectedTextOffsets()
+
+      eventEmitter.emit('textae-event.editor.selected-text.change')
+    })
+  }
+
   get selectedText() {
-    // This is a dummy implementation.
     return {
-      begin: 0,
-      end: 100,
+      begin: this.#startOffset,
+      end: this.#endOffset,
       status: 'selected'
     }
+  }
+
+  #updateSelectedTextOffsets() {
+    const selection = document.getSelection()
+    if (selection && selection.rangeCount > 0) {
+      const range = selection.getRangeAt(0)
+      const textBoxes = document.querySelectorAll('.textae-editor__text-box')
+
+      textBoxes.forEach((textBox) => {
+        if (textBox.contains(range.startContainer)) {
+          this.#startOffset = this.#getOffsetInContainer(
+            textBox,
+            range.startContainer,
+            range.startOffset
+          )
+          this.#endOffset = this.#getOffsetInContainer(
+            textBox,
+            range.endContainer,
+            range.endOffset
+          )
+        }
+      })
+    }
+  }
+
+  #getOffsetInContainer(container, node, offset) {
+    let current = node
+    let totalOffset = offset
+
+    while (current && current !== container) {
+      while (current.previousSibling) {
+        current = current.previousSibling
+        totalOffset += current.textContent.length
+      }
+      current = current.parentNode
+    }
+
+    return totalOffset
   }
 }

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
@@ -72,7 +72,7 @@ export default class EditModeSwitch {
       commander
     )
 
-    this.#viewMode = new ViewMode()
+    this.#viewMode = new ViewMode(eventEmitter)
 
     new ModeTransitionReactor(
       editorHTMLElement,

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
@@ -72,7 +72,7 @@ export default class EditModeSwitch {
       commander
     )
 
-    this.#viewMode = new ViewMode(eventEmitter)
+    this.#viewMode = new ViewMode(editorHTMLElement, eventEmitter)
 
     new ModeTransitionReactor(
       editorHTMLElement,

--- a/src/lib/Editor/diffOfAnnotation/sortByID.js
+++ b/src/lib/Editor/diffOfAnnotation/sortByID.js
@@ -5,13 +5,15 @@ export default function sortByID({
   denotations = [],
   attributes = [],
   relations = [],
-  blocks = []
+  blocks = [],
+  selectedText
 }) {
   return {
     text,
     denotations: denotations.sort(byID),
     attributes: attributes.sort(byID),
     relations: relations.sort(byID),
-    blocks: blocks.sort(byID)
+    blocks: blocks.sort(byID),
+    selectedText
   }
 }

--- a/src/lib/Editor/filterIfModified.js
+++ b/src/lib/Editor/filterIfModified.js
@@ -4,7 +4,10 @@ export default function filterIfModified(initialAnnotation) {
   let previous = initialAnnotation
 
   return function (currentAnnotation, callback) {
-    if (diffOfAnnotation(previous, currentAnnotation)) {
+    if (
+      diffOfAnnotation(previous, currentAnnotation) ||
+      currentAnnotation.selectedText.status !== 'unselected'
+    ) {
       previous = currentAnnotation
       callback(currentAnnotation)
     }

--- a/src/lib/Editor/filterIfModified.js
+++ b/src/lib/Editor/filterIfModified.js
@@ -4,10 +4,7 @@ export default function filterIfModified(initialAnnotation) {
   let previous = initialAnnotation
 
   return function (currentAnnotation, callback) {
-    if (
-      diffOfAnnotation(previous, currentAnnotation) ||
-      currentAnnotation.selectedText.status !== 'unselected'
-    ) {
+    if (diffOfAnnotation(previous, currentAnnotation)) {
       previous = currentAnnotation
       callback(currentAnnotation)
     }

--- a/src/lib/Editor/index.js
+++ b/src/lib/Editor/index.js
@@ -222,7 +222,8 @@ export default class Editor {
 
   get #inspectReport() {
     return {
-      ...this.#annotationModel.externalFormat
+      ...this.#annotationModel.externalFormat,
+      selectedText: this.#useCase.getSelectedText()
     }
   }
 }


### PR DESCRIPTION
## 概要

- エディットモードでテキスト選択時のコールバックにselectedTextを追加しました。
- ビューモードでテキスト選択時にも上記のコールバックが返ってくるように修正しました。

## 動作確認

- エディットモードでannotation編集時に返ってくるコールバックの中に、selectedTextが入っていることを確認しました。

<img width="1348" alt="スクリーンショット 2025-07-08 17 48 14" src="https://github.com/user-attachments/assets/253426f8-7362-48e3-a52d-0948601bd8fb" />

- ビューモードでテキスト選択時、コールバックが返ってくること、その中にselectedTextが含まれていることを確認しました。

<img width="1350" alt="スクリーンショット 2025-07-08 17 49 14" src="https://github.com/user-attachments/assets/a94cd7da-ef86-4ee7-960c-742a51650c3a" />

- 文字数を計算するツールで、選択範囲の文字数が意図したものになっているか確認しました。
