### PR TITLE
Replace string selection position retrieval with annotationModel.textSelection in ViewMode

### DIFF
--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
@@ -3,13 +3,15 @@ import debounce300 from '../../../../debounce300'
 
 export default class ViewMode extends EditMode {
   #editorHTMLElement
+  #annotationModel
   #startOffset
   #endOffset
 
-  constructor(editorHTMLElement, eventEmitter) {
+  constructor(editorHTMLElement, eventEmitter, annotationModel) {
     super()
 
     this.#editorHTMLElement = editorHTMLElement
+    this.#annotationModel = annotationModel
 
     const emitSelectedTextChange = debounce300(() => {
       this.#updateSelectedTextOffsets()
@@ -46,35 +48,12 @@ export default class ViewMode extends EditMode {
         textBox.contains(range.startContainer) &&
         textBox.contains(range.endContainer)
       ) {
-        this.#startOffset = this.#getOffsetInContainer(
-          textBox,
-          range.startContainer,
-          range.startOffset
-        )
-        this.#endOffset = this.#getOffsetInContainer(
-          textBox,
-          range.endContainer,
-          range.endOffset
-        )
+        this.#startOffset = this.#annotationModel.textSelection.begin
+        this.#endOffset = this.#annotationModel.textSelection.end
       }
     } else {
       this.#startOffset = undefined
       this.#endOffset = undefined
     }
-  }
-
-  #getOffsetInContainer(container, node, offset) {
-    let current = node
-    let totalOffset = offset
-
-    while (current && current !== container) {
-      while (current.previousSibling) {
-        current = current.previousSibling
-        totalOffset += current.textContent.length
-      }
-      current = current.parentNode
-    }
-
-    return totalOffset
   }
 }

--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/index.js
@@ -72,7 +72,11 @@ export default class EditModeSwitch {
       commander
     )
 
-    this.#viewMode = new ViewMode(editorHTMLElement, eventEmitter)
+    this.#viewMode = new ViewMode(
+      editorHTMLElement,
+      eventEmitter,
+      annotationModel
+    )
 
     new ModeTransitionReactor(
       editorHTMLElement,


### PR DESCRIPTION
## 概要

ViewModeでテキストの選択範囲を取得する処理をAnnotationModel.textSelectionに置き換えました。


## 動作確認

テキストを選択したとき、コンソールにテキスト選択状態に関する情報を含んだコールバックが表示されることを確認しました。
文字数を確認するツールで、選択した範囲とコンソールの表示が一致していることを確認しました。
<img width="1221" alt="スクリーンショット 2025-07-10 11 58 17" src="https://github.com/user-attachments/assets/0fef7a1c-1992-46cc-b6cb-fe7224740226" />
