### PR TITLE
Add cross boundary detection to ViewMode

### DIFF
--- a/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
+++ b/src/lib/Editor/UseCase/Presenter/EditModeSwitch/ViewMode.js
@@ -29,6 +29,17 @@ export default class ViewMode extends EditMode {
       }
     }
 
+    if (
+      this.#annotationModel.isBoundaryCrossingWithOtherSpans(
+        this.#startOffset,
+        this.#endOffset
+      )
+    ) {
+      return {
+        status: 'cross boundary detected'
+      }
+    }
+
     return {
       begin: this.#startOffset,
       end: this.#endOffset,


### PR DESCRIPTION
## 概要

ViewMode.jsでcross boundaryを検知できるようにしました。
cross boundaryを検知した場合、selectedTextが`{status: 'cross boundary detected'}`を返すようにしました。


## 動作確認

spanが何もない部分を選択した場合、通常通りbeginとendが返ってくることを確認しました。
spanの一部と他の部分を選択したとき、`{status: 'cross boundary detected'}`が帰ってくることを確認しました。

<img width="1221" alt="スクリーンショット 2025-07-10 14 33 49" src="https://github.com/user-attachments/assets/bad0d994-324c-4f61-97d0-8d365c94a872" />
