### PR TITLE
Add GitHub Actions workflow for npm publishing

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,0 +1,34 @@
+name: NPM Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - stable/4
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## 概要

- https://github.com/pubannotation/simple_inline_annotation_format/blob/master/.github/workflows/npm_release.yml
- https://docs.github.com/ja/actions/how-tos/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry

  - 以上をベースにnpm publishするワークフローを作成しました。
    - バージョンタグのついたコミットが`stable/4`ブランチにマージされると実行される設定になっています
    - simple inline annotation formatと同様に`secrets.NPM_TOKEN`を設定する必要があります

## 動作確認

TextAE上では実際に動作するか確認できていません。