### PR TITLE
Restrict npm publish workflow to version-tagged commits only

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - stable/4
 
 jobs:
   publish:


### PR DESCRIPTION
## 概要

https://github.com/pubannotation/textae/actions/runs/16263526077/job/45913976237

`npm publish`を実行するワークフローが意図せず実行されていました。
バージョンタグがついたコミットが`stable/4`にマージされたときに実行されると思っていたのですが、 #217 ではどちらかに合致していれば実行されるようになっていました。

今回の変更で、ワークフローの実行をバージョンタグがついたコミットがプッシュされたときのみに限定しました。